### PR TITLE
Fix refresh-website-content.sh path resolution

### DIFF
--- a/.ci-scripts/refresh-website-content.sh
+++ b/.ci-scripts/refresh-website-content.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 REF_DIR="$REPO_DIR/pony-ref/references"
 
 echo "Fetching website content..."

--- a/.github/workflows/pr-repo-hygiene.yml
+++ b/.github/workflows/pr-repo-hygiene.yml
@@ -23,3 +23,11 @@ jobs:
           VALIDATE_BASH: true
           VALIDATE_MD: true
           VALIDATE_YAML: true
+
+  refresh-website-content:
+    name: Verify refresh-website-content script runs successfully
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Run refresh-website-content.sh
+        run: .ci-scripts/refresh-website-content.sh


### PR DESCRIPTION
REPO_DIR was set to the script's own directory (.ci-scripts/) instead of the repository root, so the output path .ci-scripts/pony-ref/references/ didn't exist and curl failed silently with -f.

Also adds the refresh script as a PR CI job so path issues like this get caught before merge.