### PR TITLE
Add pony-ffi-audit skill

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,2 @@
 pony-ref/
+pony-ffi-audit/

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ No re-install needed — the symlinks point to your clone, so pulling new conten
 Remove the symlinks for each installed skill:
 
 ```bash
-rm ~/.claude/skills/pony-ref
-# repeat for any other installed skills
+rm ~/.claude/skills/pony-ref ~/.claude/skills/pony-ffi-audit
 ```
 
 This only removes the symlinks, not the cloned repo.
@@ -56,3 +55,22 @@ What's in the `references/` directory (read on demand for deeper questions):
 - **Runtime/GC synopsis** — ORCA object GC, MAC actor cycle collection, per-actor heaps, causal messaging, the scheduler. Includes an "Implementation Divergences" section documenting where the current ponyc runtime has evolved beyond the papers.
 - **Academic papers** — the full text of all nine Pony papers covering the type system, garbage collection, generics, and distributed programming.
 - **Website content** — snapshots of the Pony tutorial, patterns cookbook, and main website (via their llms.txt files). Covers language fundamentals, idiomatic patterns, tooling guides, and FAQ.
+
+### pony-ffi-audit
+
+Audit methodology for finding dangerous FFI usage in Pony codebases. Load it with `/pony-ffi-audit` before auditing a project's C-FFI calls for reference capability violations.
+
+Pony's FFI declarations are trusted by the compiler — if you declare a parameter as `tag` but C writes through it, nothing catches the violation at compile time. This skill teaches Claude how to find those gaps systematically.
+
+What's in the quick reference (loaded into context automatically):
+
+- The FFI trust boundary and refcap mutation rules
+- Step-by-step audit methodology (find calls, determine mutation, check caps, classify)
+- How to identify which arguments a C function mutates (common C functions, OpenSSL, PCRE2, Windows APIs)
+- Known patterns: `.cpointer()`/`.cstring()` returning `tag`, structs declared `tag`, FFI-allocated buffers with wrong cap, runtime event handles, finalizer `box`
+- Escape hatches: `addressof` and `USize` coercion bypasses
+- Fix strategies for each pattern category
+
+What's in the `references/` directory (read on demand):
+
+- **Example audit** — a condensed real-world audit showing the reporting format, classification, and summary structure across multiple projects and all pattern categories.

--- a/pony-ffi-audit/SKILL.md
+++ b/pony-ffi-audit/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: pony-ffi-audit
+description: Audit Pony FFI code for capability violations — C functions mutating through non-mutable refcaps. Load before auditing FFI safety.
+disable-model-invocation: false
+---
+
+# Pony FFI Safety Audit
+
+## The FFI Trust Boundary
+
+Pony's reference capabilities enforce memory safety at compile time, but FFI
+declarations are trusted. The programmer specifies refcaps in FFI declarations
+and the compiler takes them at face value. If a C function mutates data through
+a pointer declared as `tag` or `val` in Pony, the type system's guarantees are
+silently violated. The compiler won't catch it. The code will compile, run, and
+corrupt memory safety invariants without warning.
+
+An FFI safety audit finds these violations by examining every FFI call site,
+determining what C actually does with each argument, and checking whether the
+Pony refcap permits it.
+
+## Refcap Mutation Rules
+
+| Cap   | Mutation | Safe for C to write through? |
+|-------|----------|------------------------------|
+| `iso` | yes      | yes |
+| `trn` | yes      | yes |
+| `ref` | yes      | yes |
+| `val` | no       | **no — violation** |
+| `box` | no       | **no — violation** |
+| `tag` | no       | **no — violation** |
+
+Any FFI call where C mutates data through a `val`, `box`, or `tag` reference
+is a finding.
+
+## Audit Methodology
+
+The methodology is pattern-agnostic. It catches any violation, not just known
+patterns.
+
+### Step 1: Find all FFI call sites
+
+Search for `@` prefixed function calls in `.pony` files. These are FFI calls:
+
+```pony
+@read(fd, buffer.cpointer(), buffer.size())
+@pony_os_sockname(_fd, ip)
+```
+
+Also find FFI declarations to understand declared parameter caps:
+
+```pony
+use @read[ISize](fd: I32, buffer: Pointer[U8] tag, size: USize)
+```
+
+### Step 2: Determine what C mutates
+
+For each FFI call, identify which arguments the C function writes to. This
+requires knowing the C function's semantics (see "Identifying Mutated
+Arguments" below).
+
+### Step 3: Check the refcap
+
+For each mutated argument, determine the Pony refcap at the call site. If the
+refcap is `val`, `box`, or `tag`, it's a violation.
+
+The refcap comes from two places:
+- The **call site expression** — what cap does the argument actually have?
+- The **FFI declaration** — what cap does the declaration allow?
+
+Both matter. Flag both kinds of problems:
+- A specific call site passing a non-mutable cap to a mutating function
+- A declaration that *allows* non-mutable caps even when current call sites
+  happen to pass mutable ones (future call sites could pass `tag`)
+
+Also check the **return type of allocation FFI calls**. If an FFI function that
+allocates a buffer declares its return type as `val` (e.g.,
+`@ponyint_pool_alloc_size[Pointer[U8] val]`), the buffer is born with the
+wrong cap — C writes into it immediately after allocation, but Pony thinks
+it's immutable from the start.
+
+### Step 4: Check for escape hatches
+
+Two mechanisms bypass refcap checking entirely:
+
+**`addressof` on fields** — always produces `Pointer[FieldType] ref` regardless
+of the receiver's cap. A `fun box` method can create a `ref` pointer to a field
+via `addressof`, then pass it to C for mutation:
+
+```pony
+fun box get_token(handle: Pointer[None] tag): Bool =>
+  // addressof creates Pointer[Pointer[None]] ref even though receiver is box
+  @OpenProcessToken(handle, rights, addressof _token)
+```
+
+**`USize` coercion** — calling `.usize()` on a Pointer converts it to a plain
+integer, completely bypassing refcap tracking. The FFI system treats `USize` as
+an integer, not a capability-tracked reference:
+
+```pony
+// _ptr is Pointer[U8] — its cap is irrelevant after .usize()
+@memmove(_ptr.usize(), src.usize(), count)
+```
+
+### Step 5: Classify and report
+
+Report each finding with enough context to understand and fix it:
+
+| Line | FFI Call | Problematic Arg | Refcap | Why |
+|------|----------|-----------------|--------|-----|
+
+Group findings by file and project. Summarize with a pattern breakdown table
+showing how many findings fall into each category.
+
+## Identifying Mutated Arguments
+
+Knowing which arguments a C function writes to is the core skill. Several
+heuristics help, but none substitute for actually understanding the C function.
+
+**Check C headers for `const` qualifiers.** A `const` pointer parameter is
+read-only. A non-const pointer parameter *may* be written to (not all are, but
+it's the first signal).
+
+**Look for `out` parameter naming conventions.** Many C APIs name output
+parameters `out`, `result`, `buf`, `dst`, or `dest`.
+
+**Know the common C functions:**
+
+| C function | Mutated argument | What it writes |
+|------------|------------------|----------------|
+| `read` / `_read` | buffer (2nd arg) | file data |
+| `recv` / `recvfrom` | buffer (2nd arg) | network data |
+| `snprintf` / `_snprintf` | buffer (1st arg) | formatted string |
+| `memcpy` / `memmove` | dest (1st arg) | copied bytes |
+| `getsockopt` | value buffer (4th arg) | socket option value |
+| `WideCharToMultiByte` | output buffer (5th arg) | converted string |
+
+**Know common library functions:**
+
+| Library | Functions | Mutated argument |
+|---------|-----------|------------------|
+| OpenSSL | `EVP_DigestFinal_ex`, `RAND_bytes`, `SSL_read`, `BIO_read`, `HMAC`, `PKCS5_PBKDF2_HMAC` | output buffer param |
+| PCRE2 | `pcre2_substring_copy_*`, `pcre2_substitute_*` | output buffer param |
+| Windows | `ReadFile`, `OpenProcessToken` | output buffer / handle param |
+
+**For custom FFI functions**, read the C source. There is no shortcut.
+
+**For Pony runtime functions** (`pony_os_*`, `pony_asio_*`), check the runtime
+C source in the ponyc repo under `src/libponyrt/` and `src/common/`.
+
+## Known Patterns
+
+These are recurring patterns found across Pony codebases. They're not an
+exhaustive taxonomy — any mutation through a non-mutable cap is a violation
+regardless of whether it fits one of these. But these are especially prevalent
+and worth recognizing.
+
+### `.cpointer()` / `.cstring()` returning `Pointer tag`
+
+The most common pattern. `Array.cpointer()` and `String.cstring()` always
+return `Pointer[X] tag` regardless of the receiver's refcap. Even when the
+underlying Array or String is `iso` or `ref` (mutable and exclusively owned),
+the extracted pointer loses that information. Every FFI call that writes into
+a Pony-managed buffer goes through a `tag` pointer.
+
+```pony
+// data is Array[U8] ref — mutable, writable
+// but data.cpointer() returns Pointer[U8] tag — "identity only, no read/write"
+// and C writes into this buffer via read()
+@read(fd, data.cpointer(), data.size())
+```
+
+### Structs declared `tag` in FFI but C writes their fields
+
+FFI declarations use `tag` for struct parameters that C mutates. The Pony
+object is `ref` at the call site (inside a constructor or `ref` method), but
+the FFI declaration's `tag` cap means nothing prevents passing a `val` or `tag`
+reference from another call site.
+
+```pony
+// FFI declaration allows tag — too permissive
+use @pony_os_sockname[Bool](fd: U32, ip: NetAddress tag)
+
+// Call site passes ref (this is inside a constructor) — actually safe here
+// But the declaration would also accept val or tag
+@pony_os_sockname(_fd, ip)
+```
+
+### Runtime event handles (intentional)
+
+`AsioEventID` is `Pointer[AsioEvent] tag` by design — it's an opaque handle.
+C mutates internal fields through these handles (`pony_asio_event_set_readable`,
+`pony_asio_event_destroy`, etc.). This is intentional and internal to the
+runtime. Auditors should recognize these and classify them separately, not flag
+them as bugs to fix.
+
+### FFI-allocated buffers returned with wrong refcap
+
+When an FFI function allocates a buffer, its declared return type sets the
+refcap. If declared as `val`, the buffer is immutable from Pony's perspective
+even though C immediately writes into it.
+
+```pony
+// Returns val — but the buffer gets written to by @get_compiler_exe_directory
+use @ponyint_pool_alloc_size[Pointer[U8] val](size: USize)
+let buf = @ponyint_pool_alloc_size(path_size)
+@get_compiler_exe_directory(buf, path_size)  // writes into a val buffer
+```
+
+### FFI declarations using `box` for mutating C functions
+
+Pony finalizers receive `box` receivers, but finalizers often need to free C
+memory, which requires mutation. The FFI declarations use `box` as a compromise.
+This is an inherent tension with the Pony runtime.
+
+```pony
+// box because this is called from a finalizer
+use @ast_free[None](ast: Pointer[_AST] box)
+```
+
+## Fix Strategies
+
+**For `.cpointer()` / `.cstring()`**: The proposed fix (not yet implemented) is
+to change the return type to use viewpoint adaptation (`this->Pointer[A]`), so
+the pointer carries the receiver's cap. FFI declarations would also need
+updating to require `ref` for mutated parameters. With both changes, passing a
+`val` Array's `.cpointer()` to a mutating FFI function becomes a compile-time
+error.
+
+**For struct `tag` declarations**: Change the FFI declaration to use the
+appropriate mutable cap (`ref`) for parameters that C writes to.
+
+**For runtime event handles**: These are intentional. Document but don't change.
+
+**For finalizer `box`**: Inherent runtime tension. Document the compromise.
+The comment pattern "box is needed as this is called in a finalizer" makes the
+intent clear.
+
+**General principle**: Fix both the source side (where the pointer/reference is
+produced) and the sink side (the FFI declaration that accepts it). Fixing only
+one side doesn't give you compile-time enforcement.
+
+## Reference Material
+
+For a concrete example of what a completed audit looks like (reporting format,
+classification, summary structure), see `references/audit-example.md`.

--- a/pony-ffi-audit/references/audit-example.md
+++ b/pony-ffi-audit/references/audit-example.md
@@ -1,0 +1,167 @@
+# Example FFI Safety Audit
+
+This is a condensed example showing the structure and reporting format of a
+completed FFI safety audit. The findings are drawn from real Pony codebases
+across the ponylang organization.
+
+## Summary
+
+**46 distinct FFI call sites** across **8 projects** pass arguments with `val`,
+`box`, or `tag` refcaps to C functions that mutate through them.
+
+| Pattern | Count | Root Cause |
+|---------|-------|------------|
+| `.cpointer()`/`.cstring()` returns `Pointer tag` for writable buffers | 25 | `Array.cpointer()` and `String.cstring()` always return `tag` regardless of receiver cap |
+| Pony objects/structs declared `tag` in FFI but C writes to their fields | 13 | FFI declarations use `tag` for struct parameters that C mutates |
+| Runtime event handles mutated through `AsioEventID` (`Pointer[AsioEvent] tag`) | 5 categories | Intentional — `AsioEventID` is an opaque handle by design |
+| FFI declarations use `box` for mutating C functions | 4 | Finalizer pattern requires `box`, but the C functions mutate |
+
+### Escape hatches discovered
+
+- **`addressof` on fields**: Always produces `Pointer[FieldType] ref` regardless
+  of receiver cap. A `fun box` method can create a mutable-looking pointer to a
+  field via `addressof`.
+- **`USize` coercion**: Passing `_ptr.usize()` instead of `_ptr` to FFI,
+  bypassing Pointer refcap checking entirely.
+
+---
+
+## Findings
+
+### `.cpointer()` / `.cstring()` Pattern
+
+#### format/_format_float.pony
+
+| Line | FFI Call | Problematic Arg | Refcap | Why |
+|------|----------|-----------------|--------|-----|
+| 42 | `@_snprintf(s.cstring(), ...)` | `s.cstring()` (1st arg) | `Pointer[U8] tag` | `snprintf` writes formatted float into buffer |
+| 44 | `@snprintf(s.cstring(), ...)` | `s.cstring()` (1st arg) | `Pointer[U8] tag` | Same, non-Windows path |
+
+#### files/file.pony
+
+| Line | FFI Call | Problematic Arg | Refcap | Why |
+|------|----------|-----------------|--------|-----|
+| 233 | `@_read(_fd, result.cpointer(), ...)` | `result.cpointer()` (2nd arg) | `Pointer[U8] tag` | Windows `_read` writes file data into buffer |
+| 235 | `@read(_fd, result.cpointer(), ...)` | `result.cpointer()` (2nd arg) | `Pointer[U8] tag` | POSIX `read` writes file data into buffer |
+
+#### net/tcp_connection.pony
+
+| Line | FFI Call | Problematic Arg | Refcap | Why |
+|------|----------|-----------------|--------|-----|
+| 921 | `@pony_os_recv(_event, _read_buf.cpointer(...), ...)` | `_read_buf.cpointer(...)` (2nd arg) | `Pointer[U8] tag` | `recv` writes network data into buffer |
+
+#### crypto/digest.pony (ssl project)
+
+| Line | FFI Call | Problematic Arg | Refcap | Why |
+|------|----------|-----------------|--------|-----|
+| 194 | `@EVP_DigestFinal_ex(_ctx, digest.cpointer(), ...)` | `digest.cpointer()` (2nd arg) | `Pointer[U8] tag` | Writes hash output into buffer |
+| 197 | `@EVP_DigestFinalXOF(_ctx, digest.cpointer(), ...)` | `digest.cpointer()` (2nd arg) | `Pointer[U8] tag` | Writes XOF hash output into buffer |
+| 199 | `@EVP_DigestFinal_ex(_ctx, digest.cpointer(), ...)` | `digest.cpointer()` (2nd arg) | `Pointer[U8] tag` | Same as line 194, else branch |
+
+#### regex/match.pony (regex project)
+
+| Line | FFI Call | Problematic Arg | Refcap | Why |
+|------|----------|-----------------|--------|-----|
+| 65-66 | `@pcre2_substring_copy_bynumber_8(_match, i, out.cpointer(), ...)` | `out.cpointer()` (3rd arg) | `Pointer[U8] tag` | Copies captured substring into buffer |
+
+---
+
+### Struct `tag` Pattern
+
+#### files/file_info.pony
+
+| Line | FFI Call | Problematic Arg | Refcap | Why |
+|------|----------|-----------------|--------|-----|
+| 101 | `@pony_os_stat(from.path.cstring(), this)` | `this` (2nd arg) | `FileInfo tag` (decl) | C writes all file metadata fields into struct |
+| 117 | `@pony_os_fstat(fd, path.path.cstring(), this)` | `this` (3rd arg) | `FileInfo tag` (decl) | Same |
+
+Note: `this` is `ref` at the call sites (inside constructors), but the FFI
+declaration accepts `tag`/`val`.
+
+#### net/tcp_connection.pony
+
+| Line | FFI Call | Problematic Arg | Refcap | Why |
+|------|----------|-----------------|--------|-----|
+| 539 | `@pony_os_sockname(_fd, ip)` | `ip` (2nd arg) | `NetAddress tag` (decl) | C writes socket address into struct |
+| 548 | `@pony_os_peername(_fd, ip)` | `ip` (2nd arg) | `NetAddress tag` (decl) | C writes peer address into struct |
+
+---
+
+### Runtime Event Handles (Intentional)
+
+These are classified separately because `AsioEventID` is `Pointer[AsioEvent]
+tag` by design — it's an opaque runtime handle.
+
+#### net/tcp_connection.pony
+
+| Lines | FFI Call | Why |
+|-------|----------|-----|
+| 425, 1095, 1126 | `@pony_asio_event_set_writeable(_event, ...)` | Writes `ev->writeable` |
+| 991, 1094 | `@pony_asio_event_set_readable(_event, ...)` | Writes `ev->readable` |
+| 624, 637, 1091 | `@pony_asio_event_unsubscribe(event)` | Writes `ev->flags` |
+| 645, 668 | `@pony_asio_event_destroy(event)` | Writes fields, frees memory |
+
+---
+
+### FFI-Allocated Buffer with Wrong Refcap
+
+#### tools/pony-doc/main.pony
+
+| Line | FFI Call | Problematic Arg | Refcap | Why |
+|------|----------|-----------------|--------|-----|
+| 155-156 | `@get_compiler_exe_directory(buf, ...)` | `buf` (1st arg) | `Pointer[U8] val` (from `ponyint_pool_alloc_size` returning `val`) | C writes exe directory path into buffer |
+
+The buffer is allocated by `@ponyint_pool_alloc_size` which is declared as
+returning `Pointer[U8] val`. The buffer is `val` from birth, but C writes
+into it immediately after allocation.
+
+Same pattern in `tools/pony-lint/main.pony` and `tools/pony-lsp/pony_compiler.pony`.
+
+---
+
+### Finalizer `box` Pattern
+
+#### pony_compiler/ast.pony
+
+| Line | FFI Declaration | Problematic Param | Refcap | Why |
+|------|-----------------|-------------------|--------|-----|
+| 17 | `@ast_free(ast: Pointer[_AST] box)` | `ast` | `box` | Writes `ast->frozen`, frees children |
+
+#### pony_compiler/_symtab.pony
+
+| Line | FFI Declaration | Problematic Param | Refcap | Why |
+|------|-----------------|-------------------|--------|-----|
+| 2 | `@symtab_free(symtab: Pointer[_Symtab] box)` | `symtab` | `box` | Destroys hash table, frees memory |
+
+Comment in source: "box is needed as this is called in a finalizer" —
+intentional compromise.
+
+---
+
+### Escape Hatches
+
+#### `addressof` bypass
+
+##### files/file_path.pony
+
+| Line | FFI Call | Problematic Arg | Refcap | Why |
+|------|----------|-----------------|--------|-----|
+| 327 | `@OpenProcessToken(handle, rights, addressof token)` | `addressof token` (3rd arg) | `Pointer[None] tag` (decl) | C writes token handle through pointer |
+
+#### `USize` coercion bypass
+
+##### builtin/string.pony
+
+`_ptr.usize()` is passed to `@memmove` instead of `_ptr`, converting the
+Pointer to a plain integer and bypassing all refcap checking. All current uses
+happen to be in `fun ref` methods so the mutation is authorized, but this
+pattern could mask violations in `box` or `val` contexts.
+
+---
+
+## Observations
+
+The most impactful root cause is `.cpointer()` / `.cstring()` always returning
+`tag`. Fixing the return type to use viewpoint adaptation (`this->Pointer[A]`)
+would address 25 of 46 findings at the source, though FFI declarations also
+need updating to enforce the correct cap at the sink side.


### PR DESCRIPTION
New skill that teaches Claude how to audit Pony codebases for dangerous FFI usage — C-FFI calls that mutate data through pointers with non-mutable reference capabilities (val, box, tag).

Pony's FFI declarations are trusted by the compiler, so refcap violations at the FFI boundary aren't caught at compile time. This skill provides a systematic methodology for finding these gaps, covering:

- The general audit process (pattern-agnostic — catches any violation, not just known patterns)
- Heuristics for identifying which C arguments are mutated (const qualifiers, common C/OpenSSL/PCRE2 functions, out parameter conventions)
- Known recurring patterns from an audit of the ponylang org repos (cpointer/cstring returning tag, structs declared tag, FFI-allocated buffers with wrong cap, runtime event handles, finalizer box)
- Escape hatches that bypass refcap checking (addressof, USize coercion)
- Fix strategies for each pattern category
- A condensed example audit in references/ demonstrating the reporting format