### PR TITLE
Add writing convention skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ No re-install needed — the symlinks point to your clone, so pulling new conten
 Remove the symlinks for each installed skill:
 
 ```bash
-rm ~/.claude/skills/pony-ref ~/.claude/skills/pony-ffi-audit
+rm ~/.claude/skills/pony-ref ~/.claude/skills/pony-ffi-audit ~/.claude/skills/pony-examples-readme ~/.claude/skills/pony-library-readme ~/.claude/skills/pony-release-notes
 ```
 
 This only removes the symlinks, not the cloned repo.
@@ -74,3 +74,60 @@ What's in the quick reference (loaded into context automatically):
 What's in the `references/` directory (read on demand):
 
 - **Example audit** — a condensed real-world audit showing the reporting format, classification, and summary structure across multiple projects and all pattern categories.
+
+### pony-examples-readme
+
+Conventions for writing `examples/README.md` files in ponylang projects. Load it with `/pony-examples-readme` when adding, updating, or reorganizing examples.
+
+What's in the quick reference:
+
+- Structure conventions (title, intro paragraph, example entries, category grouping)
+- Description format (what it does, what it demonstrates, key concepts)
+- Ordering strategies (by complexity, by category, by directory name)
+- What to omit (build instructions, source code snippets, detailed setup)
+
+### pony-library-readme
+
+Conventions for writing Pony library project READMEs. Load it with `/pony-library-readme` when writing or updating a library's top-level README.
+
+What's in the quick reference:
+
+- Required sections in order (title, intro, status, installation, API documentation)
+- Optional sections (dependencies, usage with inline code examples)
+- What ponylang library READMEs deliberately omit (badges, contributing, license, table of contents)
+
+### pony-release-notes
+
+How to write release notes and manage CHANGELOG entries in ponylang projects. Load it with `/pony-release-notes` when writing release notes, updating CHANGELOG, or preparing a PR with user-facing changes.
+
+What's in the quick reference:
+
+- Writing style (user-focused descriptions, dependency bugs as your bugs, breaking change before/after examples)
+- Mechanics (`.release-notes/` directory, individual files per PR, CI aggregation)
+- Changelog labels (`changelog - fixed`, `changelog - added`, `changelog - changed`)
+- Single-type vs. multi-type PR workflows
+- Rules for updating accumulated unreleased notes
+
+## Suggested Triggers
+
+Add these to your `CLAUDE.md` or `AGENTS.md` to load skills automatically when relevant:
+
+### /pony-ref
+
+> **Load `/pony-ref` proactively when working on Pony code**: At the start of any conversation where the working directory is a Pony project (contains `corral.json` or `*.pony` files), load `/pony-ref` before doing any work. Also load it mid-conversation when hitting capabilities, type system, runtime, or testing questions.
+
+### /pony-ffi-audit
+
+> **Load `/pony-ffi-audit` before auditing FFI calls**: Load it before auditing a Pony project's C-FFI calls for reference capability violations, mutation through `tag` references, or other FFI trust boundary issues.
+
+### /pony-examples-readme
+
+> **Load `/pony-examples-readme` when working on examples**: Load it when adding, updating, or reorganizing examples in a Pony project, or when writing an `examples/README.md`.
+
+### /pony-library-readme
+
+> **Load `/pony-library-readme` for library READMEs**: Load it when writing or updating a `README.md` for a Pony library project.
+
+### /pony-release-notes
+
+> **Load `/pony-release-notes` for release notes and CHANGELOG**: Load it when writing release notes, updating CHANGELOG, or preparing a PR that includes user-facing changes in a Pony project.

--- a/pony-examples-readme/SKILL.md
+++ b/pony-examples-readme/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: pony-examples-readme
+description: Conventions for Pony examples/README.md files. Load when adding, updating, or reorganizing examples in a ponylang project.
+disable-model-invocation: false
+---
+
+# Pony Examples README Conventions
+
+These conventions are derived from existing ponylang examples/README.md files (postgres, redis, lori, crdt, uri, web_link). Follow them when writing or updating an examples/README.md.
+
+## Structure
+
+1. **Title** — Always `# Examples`.
+
+2. **Intro paragraph** (no heading) — 1-3 sentences describing what the examples are and any useful context. Standard phrasing for library examples: "Each subdirectory is a self-contained Pony program demonstrating a different part of the X library." If examples are ordered by complexity or grouped by category, state that here.
+
+3. **Example entries** — One `##` heading per example, using the directory name as the heading text. Optionally link to the directory: `## [example-name](example-name/)`.
+
+4. **Category grouping** (when applicable) — If examples fall into natural categories, use `##` for category headings and `###` for individual examples within each category.
+
+5. **Start-here marker** — When one example is clearly the simplest entry point, end its description with: "Start here if you're new to the library."
+
+## Example Descriptions
+
+Each example gets a paragraph of 2-4 sentences covering:
+
+- **What it does**: The concrete workflow in present tense, third person ("Connects to Redis, executes SET, prints the response, and closes the session.")
+- **What it demonstrates**: The specific APIs, interfaces, or patterns exercised, named with backtick formatting (e.g., "`Session.prepare()` and `NamedPreparedQuery`")
+- **Key concepts**: Any non-obvious behavior, design pattern, or protocol detail the example illustrates
+
+## Ordering
+
+Choose one strategy and make it clear from the intro paragraph or the order itself:
+
+- **By complexity** (simplest first) — Best when examples build on each other conceptually. State the ordering in the intro: "Ordered from simplest to most involved."
+- **By category** — Best when examples cover distinct feature areas. Use `##` categories with `###` examples.
+- **By directory name** — Acceptable when no natural ordering exists.
+
+## What to Omit
+
+- **Build instructions** — Build commands belong in the project's top-level README or Makefile. Exception: if examples have a separate build target (e.g., `make build-examples`), a one-line note in the intro is acceptable.
+- **Source code snippets** — The README describes what each example does; the code speaks for itself.
+- **Detailed setup instructions** — If an example needs external services (a database, Redis server, TLS certificates), mention it briefly in that example's description. Detailed setup belongs in the example's own directory.

--- a/pony-library-readme/SKILL.md
+++ b/pony-library-readme/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: pony-library-readme
+description: Conventions for Pony library project READMEs. Load when writing or updating a README.md for a ponylang library project.
+disable-model-invocation: false
+---
+
+# Pony Library README Conventions
+
+These conventions are derived from existing ponylang library READMEs and should be followed when writing or updating a README.md for a Pony library project.
+
+## Required Sections (in order)
+
+Every Pony library README has these sections in this order:
+
+1. **Title** (`#`) — Lowercase matching the repo/package name (e.g., `# glob`, `# web_link`). Use proper capitalization only for proper nouns or acronyms (e.g., `# PEG`, `# Lori`, `# GitHub REST API`).
+
+2. **Intro paragraph** (no heading) — 1-2 sentences describing what the library does. No section heading.
+
+3. **`## Status`** — Short maturity statement. Common values:
+   - `Production ready.`
+   - `Beta`
+   - `[Name] is beta-level software.`
+   - Longer form: `[Name] is beta quality software that will change frequently. Expect breaking changes. That said, you should feel comfortable using it in your projects.`
+
+4. **`## Installation`** — Standard 5-bullet list using `*` markers:
+   ```markdown
+   * Install [corral](https://github.com/ponylang/corral)
+   * `corral add github.com/ponylang/<name>.git --version <X.Y.Z>`
+   * `corral fetch` to fetch your dependencies
+   * `use "<package>"` to include this package
+   * `corral run -- ponyc` to compile your application
+   ```
+   If the package has sub-packages, the `use` bullet gets sub-bullets listing each (e.g., `use "ssl/crypto"`, `use "ssl/net"`).
+
+5. **`## API Documentation`** — A markdown link to the docs: `[https://ponylang.github.io/<name>](https://ponylang.github.io/<name>)`. This is always the last section (or near-last if a project-specific section follows).
+
+## Optional Sections
+
+These go between Installation and API Documentation, in this order:
+
+- **`## Dependencies`** — Only include when the library requires native C libraries the user must install (e.g., libpcre2, OpenSSL). If the dependency is transitive via the `ssl` package, a note after the installation bullets linking to ssl's installation instructions is sufficient instead of a full section.
+
+- **`## Usage`** — Always include an inline code example showing core usage (a complete short program or a structural skeleton). Point to the `examples/` directory for more.
+
+## Things Pony Library READMEs Do NOT Have
+
+- No CI/coverage/version badges
+- No "Contributing" section (that goes in CONTRIBUTING.md)
+- No "License" section (that goes in LICENSE)
+- No "Table of Contents"

--- a/pony-release-notes/SKILL.md
+++ b/pony-release-notes/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: pony-release-notes
+description: Load when writing release notes, updating CHANGELOG, or preparing a PR that includes user-facing changes in a Pony project.
+disable-model-invocation: false
+---
+
+# Pony Release Notes & CHANGELOG
+
+## Writing Style
+
+**Release notes — write for end users, not developers**: Release notes describe user-visible changes only. Omit implementation details (internal refactoring, which functions changed, how the fix works). Focus on what the user experienced before, what they experience now, and why it matters. When introducing new API surface, include a short code example — a concise usage snippet communicates more than descriptive text. Changes that are only relevant to maintainers (internal documentation, code comments, refactoring with no user-visible effect) don't get release notes at all.
+
+**Dependency bugs are your bugs**: When a dependency upgrade fixes a bug, write the release note as if it's your bug. The user doesn't care which layer caused it — they care that the library they use had a problem and now it doesn't. Don't mention the dependency name, don't say "upgrades X to Y," don't write "the underlying Z library." Just describe the problem and that it's fixed.
+
+**Dependency upgrades can produce multiple change types**: A single dependency upgrade might bring new features (added), bug fixes (fixed), and breaking changes (changed). Evaluate each user-visible consequence independently rather than treating the upgrade as one item. A dependency bump that fixes two bugs and adds a feature is three release note entries, not one.
+
+**Breaking changes need before/after examples**: When a release note describes a breaking change, include before/after code snippets showing what users need to change. This lets users quickly see the migration path without reading the full description.
+
+**Code examples should show contrast, not compressed workflows**: When a documentation example's purpose is "here's an alternative way to do X," show the two approaches to the same operation side by side. Don't try to compress a full end-to-end workflow into a tiny snippet with `// ...` placeholders — it loses clarity. This applies to READMEs, release notes, and docstrings.
+
+**One paragraph per line**: Each prose paragraph in a release note should be a single line (no hard wraps). Code blocks are exempt — they follow their natural formatting. This matches how the CI tooling aggregates release notes.
+
+## Mechanics
+
+**How to add release notes in Pony projects**: Create a `.md` file in the `.release-notes/` directory with any unique, descriptive name (e.g., `remove-command.md`). Format: `## Title` followed by an end-user description. Do NOT edit `next-release.md` directly — CI aggregates the individual files into that on release. The file can be included in the PR that introduces the change.
+
+**Three types of user-facing changes**: Fixed (bug fixes), Added (new features), Changed (breaking changes or conceptual changes). Most PRs are a single type, which the automation handles — do NOT include a manual CHANGELOG step in plans for single-type PRs. After opening the PR, apply the corresponding label so CI knows which CHANGELOG section to use: `changelog - fixed`, `changelog - added`, or `changelog - changed`. When a PR spans multiple types (e.g., both Added and Changed), the automation can't handle it — you must manually:
+1. Open the PR first to get a PR number.
+2. Update `CHANGELOG.md` directly, adding a line to each relevant section under `[unreleased]`. Each line should be the best short description for that specific change (not necessarily the PR title), formatted as `- Description ([PR #N](url))`. A single PR can have multiple entries in the same section (e.g., multiple Changed lines) if there are multiple distinct breaking changes.
+3. Append the release notes directly to `.release-notes/next-release.md` — one `## Title` section per change type.
+4. Do NOT create an individual `.release-notes/*.md` file for multi-type PRs.
+5. Do NOT apply a `changelog` label — labels and manual CHANGELOG/next-release.md edits are mutually exclusive.
+
+**PR title must match release note title for single-type PRs**: When using a changelog label, the automation uses the PR title as the CHANGELOG entry. The release note heading (the `## Title` line) and the PR title must be the same text, so users see a consistent name in the CHANGELOG and the release notes.
+
+**Breaking changes must update existing unreleased notes**: When a breaking change modifies API that an earlier unreleased PR introduced, check `next-release.md` for code examples or descriptions that reference the old API. Accumulated unreleased notes go stale when a later PR breaks something an earlier one added.
+
+**Omit never-released features entirely**: If a feature was introduced and removed between releases (never shipped to users), it should not appear in release notes or CHANGELOG at all. Users never saw it, so documenting its addition or removal is meaningless. Describe the net change from the last release to the current state.
+
+**Only make factual changes to existing entries**: When updating accumulated unreleased notes, only change content that is factually wrong (stale API references, incorrect descriptions). Do not make grammar, formatting, or stylistic edits to entries from earlier PRs.


### PR DESCRIPTION
Adds three skills that were developed in a private config repo and have proven useful enough to share with the community:

- **pony-examples-readme** -- conventions for writing examples/README.md files in ponylang projects
- **pony-library-readme** -- conventions for writing Pony library project READMEs
- **pony-release-notes** -- how to write release notes and manage CHANGELOG entries

Also adds a Suggested Triggers section to the README with copy-pasteable CLAUDE.md instructions for all five skills (the two existing ones plus these three), and updates the uninstall command to include the new skill names.