### PR TITLE
Add --uninstall support to install.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@ No re-install needed — the symlinks point to your clone, so pulling new conten
 
 ### Uninstalling
 
-Remove the symlinks for each installed skill:
-
 ```bash
-rm ~/.claude/skills/pony-ref ~/.claude/skills/pony-ffi-audit ~/.claude/skills/pony-examples-readme ~/.claude/skills/pony-library-readme ~/.claude/skills/pony-release-notes ~/.claude/skills/pony-software-design ~/.claude/skills/pony-code-review ~/.claude/skills/pony-test-design ~/.claude/skills/pony-ensemble ~/.claude/skills/pony-synthesize ~/.claude/skills/pony-pbt-patterns ~/.claude/skills/pony-debug
+python install.py --uninstall
 ```
 
 This only removes the symlinks, not the cloned repo.

--- a/install.py
+++ b/install.py
@@ -3,6 +3,7 @@
 
 Usage:
     python install.py              Install (create symlinks)
+    python install.py --uninstall  Remove all symlinks pointing into this repo
     python install.py --dry-run    Show what would be done without doing it
 
 What it does:
@@ -75,6 +76,31 @@ def remove_stale_symlinks(repo, skills_dst, dry_run):
             print(f"  remove: {entry}")
 
 
+def uninstall(repo, skills_dst, dry_run):
+    """Remove all symlinks in skills_dst that point into repo."""
+    if not skills_dst.is_dir():
+        print("Nothing to uninstall (skills directory does not exist).")
+        return
+    removed = []
+    for entry in sorted(skills_dst.iterdir()):
+        if not entry.is_symlink():
+            continue
+        target = entry.resolve()
+        try:
+            target.relative_to(repo.resolve())
+        except ValueError:
+            continue
+        removed.append(entry)
+    if not removed:
+        print("No symlinks pointing into this repo found.")
+        return
+    print("Removing:")
+    for entry in removed:
+        if not dry_run:
+            entry.unlink()
+        print(f"  {entry}")
+
+
 def main():
     """Install skills by symlinking into ~/.claude/skills/."""
     if len(sys.argv) > 1 and sys.argv[1] in ("-h", "--help"):
@@ -89,22 +115,25 @@ def main():
     repo = repo_dir()
     home = claude_home()
 
-    # Symlink each skill directory (top-level dirs containing SKILL.md)
-    print("Skills:")
-    found_any = False
-    for skill_dir in sorted(repo.iterdir()):
-        if not skill_dir.is_dir():
-            continue
-        if not (skill_dir / "SKILL.md").exists():
-            continue
-        found_any = True
-        dst = home / "skills" / skill_dir.name
-        print(symlink(skill_dir, dst, dry_run))
+    if "--uninstall" in sys.argv:
+        uninstall(repo, home / "skills", dry_run)
+    else:
+        # Symlink each skill directory (top-level dirs containing SKILL.md)
+        print("Skills:")
+        found_any = False
+        for skill_dir in sorted(repo.iterdir()):
+            if not skill_dir.is_dir():
+                continue
+            if not (skill_dir / "SKILL.md").exists():
+                continue
+            found_any = True
+            dst = home / "skills" / skill_dir.name
+            print(symlink(skill_dir, dst, dry_run))
 
-    if not found_any:
-        print("  (no skill directories found)")
+        if not found_any:
+            print("  (no skill directories found)")
 
-    remove_stale_symlinks(repo, home / "skills", dry_run)
+        remove_stale_symlinks(repo, home / "skills", dry_run)
 
     if dry_run:
         print("\n=== DRY RUN complete (no changes were made) ===")


### PR DESCRIPTION
The hardcoded `rm` command in the README doesn't scale — every new skill requires updating it. `install.py` already knows how to discover repo symlinks (`remove_stale_symlinks` does this), so `--uninstall` reuses that same walk but removes all repo symlinks, not just stale ones.

Changes:
- Add `uninstall()` function and `--uninstall` CLI flag to `install.py`
- Update module docstring with new usage line
- Replace hardcoded `rm` in README with `python install.py --uninstall`

Supports `--dry-run` for preview, same as install mode.

Closes #19