### PR TITLE
Add changelog and automation

### DIFF
--- a/.ci-scripts/changelog.py
+++ b/.ci-scripts/changelog.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Manage CHANGELOG.md for a rolling, date-based changelog.
+
+Entries are grouped by date (UTC) with newest first. Each entry is
+prefixed with ADDED, FIXED, or CHANGED to categorize the change.
+
+Subcommands:
+  add-entry    Add an entry under today's UTC date section.
+  validate     Check that CHANGELOG.md is well-formed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+ENTRY_PREFIX_RE = re.compile(r"^- (ADDED|FIXED|CHANGED): ")
+
+EXPECTED_HEADER_FRAGMENT = "# Change Log"
+
+VALID_TYPES = ("added", "fixed", "changed")
+
+
+def _read_changelog() -> str:
+    if not CHANGELOG.exists():
+        print(f"ERROR: {CHANGELOG} not found", file=sys.stderr)
+        sys.exit(1)
+    return CHANGELOG.read_text(encoding="utf-8")
+
+
+def _write_changelog(content: str) -> None:
+    CHANGELOG.write_text(content, encoding="utf-8")
+
+
+def _split_sections(content: str) -> tuple[str, list[tuple[str, str]]]:
+    """Split changelog into header and a list of (heading_line, body) pairs."""
+    lines = content.split("\n")
+    header_lines: list[str] = []
+    sections: list[tuple[str, str]] = []
+    current_heading: str | None = None
+    current_body_lines: list[str] = []
+
+    for line in lines:
+        if line.startswith("## "):
+            if current_heading is not None:
+                sections.append((current_heading, "\n".join(current_body_lines)))
+            else:
+                header_lines = current_body_lines
+            current_heading = line
+            current_body_lines = []
+        else:
+            current_body_lines.append(line)
+
+    if current_heading is not None:
+        sections.append((current_heading, "\n".join(current_body_lines)))
+    else:
+        header_lines = current_body_lines
+
+    header = "\n".join(header_lines)
+    return header, sections
+
+
+def _reassemble(header: str, sections: list[tuple[str, str]]) -> str:
+    parts = [header]
+    for heading, body in sections:
+        parts.append(heading)
+        parts.append(body)
+    return "\n".join(parts)
+
+
+def _parse_date_heading(heading: str) -> str | None:
+    """Extract date from a heading like '## 2026-04-08'."""
+    match = re.match(r"^## (\d{4}-\d{2}-\d{2})$", heading)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+# -- Subcommands -------------------------------------------------------------
+
+
+def cmd_add_entry(entry: str, entry_type: str) -> int:
+    """Add an entry under today's UTC date section."""
+    today = _today_utc()
+    today_heading = f"## {today}"
+
+    prefix = entry_type.upper()
+    formatted = f"- {prefix}: {entry}"
+
+    content = _read_changelog()
+    header, sections = _split_sections(content)
+
+    # If today's section doesn't exist, create it at the top.
+    if not sections or sections[0][0] != today_heading:
+        sections.insert(0, (today_heading, "\n"))
+
+    _, body = sections[0]
+    body_lines = body.split("\n")
+
+    # Insert after the first blank line (right after the date heading).
+    body_lines.insert(1, formatted)
+    sections[0] = (today_heading, "\n".join(body_lines))
+
+    _write_changelog(_reassemble(header, sections))
+    print(f"Added {prefix} entry under {today}")
+    return 0
+
+
+def cmd_validate() -> int:
+    """Check that CHANGELOG.md is well-formed."""
+    content = _read_changelog()
+    header, sections = _split_sections(content)
+    errors: list[str] = []
+
+    if EXPECTED_HEADER_FRAGMENT not in header:
+        errors.append("missing expected header ('# Change Log')")
+
+    # An empty changelog (no sections yet) is valid.
+    if not sections:
+        if errors:
+            _report_errors(errors)
+            return 1
+        print("Changelog validation passed.")
+        return 0
+
+    seen_dates: set[str] = set()
+    prev_date: str | None = None
+
+    for heading, body in sections:
+        date_str = _parse_date_heading(heading)
+
+        if date_str is None:
+            errors.append(f"cannot parse date from heading: '{heading}'")
+            continue
+
+        if not DATE_RE.match(date_str):
+            errors.append(f"invalid date format: '{date_str}'")
+
+        if date_str in seen_dates:
+            errors.append(f"duplicate date: {date_str}")
+        seen_dates.add(date_str)
+
+        if prev_date is not None and date_str >= prev_date:
+            errors.append(
+                f"dates out of order: {date_str} should come before {prev_date}"
+            )
+        prev_date = date_str
+
+        # Validate entry prefixes.
+        for line in body.split("\n"):
+            if line.startswith("- ") and not ENTRY_PREFIX_RE.match(line):
+                errors.append(
+                    f"entry under {date_str} missing valid prefix "
+                    f"(ADDED/FIXED/CHANGED): '{line}'"
+                )
+
+    if errors:
+        _report_errors(errors)
+        return 1
+
+    print("Changelog validation passed.")
+    return 0
+
+
+def _report_errors(errors: list[str]) -> None:
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    print(f"Changelog validation failed: {len(errors)} error(s).", file=sys.stderr)
+
+
+# -- Main --------------------------------------------------------------------
+
+
+def main() -> int:
+    """Parse arguments and dispatch to the appropriate subcommand."""
+    parser = argparse.ArgumentParser(description="Manage CHANGELOG.md")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("validate", help="Check changelog format")
+
+    add_entry_parser = sub.add_parser(
+        "add-entry", help="Add an entry under today's date section"
+    )
+    add_entry_parser.add_argument(
+        "--type",
+        required=True,
+        choices=VALID_TYPES,
+        dest="entry_type",
+        help="Type of change: added, fixed, or changed",
+    )
+    add_entry_parser.add_argument("entry", help="Entry text (without leading '- ')")
+
+    args = parser.parse_args()
+    if args.command is None:
+        parser.print_help()
+        return 1
+
+    if args.command == "validate":
+        return cmd_validate()
+    if args.command == "add-entry":
+        return cmd_add_entry(args.entry, args.entry_type)
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -1,0 +1,50 @@
+name: CI Scripts
+
+on:
+  pull_request:
+    paths:
+      - ".ci-scripts/**"
+      - "CHANGELOG.md"
+
+concurrency:
+  group: lint-changelog-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install pylint
+        run: pip install pylint
+
+      - name: Lint
+        run: pylint .ci-scripts/changelog.py
+
+  validate-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Validate changelog format
+        run: python3 .ci-scripts/changelog.py validate

--- a/.github/workflows/pr-merge-changelog.yml
+++ b/.github/workflows/pr-merge-changelog.yml
@@ -1,0 +1,105 @@
+name: PR Merge Changelog
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - CHANGELOG.md
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find merged PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Retry loop for GitHub API eventual consistency.
+          for attempt in 1 2 3; do
+            PR_JSON=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/pulls" \
+              --jq '.[0] // empty' 2>/dev/null || echo "")
+            if [ -n "$PR_JSON" ]; then
+              break
+            fi
+            echo "Attempt ${attempt}: no PR found, retrying in 10s..."
+            sleep 10
+          done
+
+          if [ -z "$PR_JSON" ]; then
+            echo "No PR found for commit — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          TITLE=$(echo "$PR_JSON" | jq -r '.title')
+          URL=$(echo "$PR_JSON" | jq -r '.html_url')
+
+          CHANGELOG_LABEL=$(echo "$PR_JSON" | jq -r \
+            '[.labels[].name] | map(select(startswith("changelog - "))) | first // empty')
+
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "changelog_label=$CHANGELOG_LABEL" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Determine change type
+        if: steps.pr.outputs.skip != 'true' && steps.pr.outputs.changelog_label != ''
+        id: type
+        env:
+          LABEL: ${{ steps.pr.outputs.changelog_label }}
+        run: |
+          case "$LABEL" in
+            "changelog - added")   echo "entry_type=added" >> "$GITHUB_OUTPUT" ;;
+            "changelog - fixed")   echo "entry_type=fixed" >> "$GITHUB_OUTPUT" ;;
+            "changelog - changed") echo "entry_type=changed" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "Unknown changelog label: $LABEL"
+              exit 1
+              ;;
+          esac
+
+      - name: Check out main
+        if: steps.pr.outputs.skip != 'true' && steps.pr.outputs.changelog_label != ''
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        if: steps.pr.outputs.skip != 'true' && steps.pr.outputs.changelog_label != ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Add changelog entry
+        if: steps.pr.outputs.skip != 'true' && steps.pr.outputs.changelog_label != ''
+        env:
+          TITLE: ${{ steps.pr.outputs.title }}
+          NUMBER: ${{ steps.pr.outputs.number }}
+          URL: ${{ steps.pr.outputs.url }}
+          ENTRY_TYPE: ${{ steps.type.outputs.entry_type }}
+        run: |
+          ENTRY="${TITLE} ([PR #${NUMBER}](${URL}))"
+          python3 .ci-scripts/changelog.py add-entry --type "$ENTRY_TYPE" "$ENTRY"
+
+      - name: Commit and push
+        if: steps.pr.outputs.skip != 'true' && steps.pr.outputs.changelog_label != ''
+        env:
+          NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "Update changelog for PR #${NUMBER}"
+          git pull --rebase origin main
+          git push origin main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. Entries
+are grouped by date (UTC) with newest first.
+
+## 2026-04-07
+
+- CHANGED: Design personas must explore before committing; orchestrator gates quality ([PR #31](https://github.com/ponylang/llm-skills/pull/31))
+- FIXED: Skeptic should redirect when subtraction removes everything ([PR #30](https://github.com/ponylang/llm-skills/pull/30))
+
+## 2026-04-04
+
+- CHANGED: Remove pony-ffi-audit skill
+- FIXED: Multi-type PR documentation in pony-release-notes ([PR #28](https://github.com/ponylang/llm-skills/pull/28))
+- ADDED: pony-debug skill ([PR #21](https://github.com/ponylang/llm-skills/pull/21))
+- ADDED: pony-ensemble skill ([PR #18](https://github.com/ponylang/llm-skills/pull/18))
+- ADDED: pony-synthesize skill ([PR #18](https://github.com/ponylang/llm-skills/pull/18))
+- ADDED: pony-software-design skill ([PR #18](https://github.com/ponylang/llm-skills/pull/18))
+- ADDED: pony-test-design skill ([PR #18](https://github.com/ponylang/llm-skills/pull/18))
+- ADDED: pony-code-review skill ([PR #18](https://github.com/ponylang/llm-skills/pull/18))
+- ADDED: pony-pbt-patterns skill ([PR #18](https://github.com/ponylang/llm-skills/pull/18))
+
+## 2026-04-02
+
+- ADDED: pony-examples-readme skill ([PR #17](https://github.com/ponylang/llm-skills/pull/17))
+- ADDED: pony-library-readme skill ([PR #17](https://github.com/ponylang/llm-skills/pull/17))
+- ADDED: pony-release-notes skill ([PR #17](https://github.com/ponylang/llm-skills/pull/17))
+
+## 2026-03-14
+
+- FIXED: pony-ref incorrectly stated _method is type-private; it is package-private ([PR #13](https://github.com/ponylang/llm-skills/pull/13))
+- FIXED: pony-ref incorrectly stated type aliases can't have docstrings ([PR #13](https://github.com/ponylang/llm-skills/pull/13))
+
+## 2026-03-10
+
+- ADDED: pony-ffi-audit skill ([PR #4](https://github.com/ponylang/llm-skills/pull/4))
+
+## 2026-03-09
+
+- ADDED: pony-ref skill ([PR #2](https://github.com/ponylang/llm-skills/pull/2))


### PR DESCRIPTION
Adds CHANGELOG.md with backfilled user-facing changes and automation to keep it maintained going forward.

- `.ci-scripts/changelog.py`: `add-entry` and `validate` subcommands
- `pr-merge-changelog` workflow: auto-adds entry on merge using `changelog - added/fixed/changed` PR labels
- `lint-changelog` workflow: validates format and lints the script on PRs