### PR TITLE
Bundle pony-code-review's principles instead of reading global CLAUDE.md

### DIFF
--- a/pony-code-review/SKILL.md
+++ b/pony-code-review/SKILL.md
@@ -84,7 +84,7 @@ When principles conflict, these values set the priority. We value the left side 
 4. **Spawn 8 persona agents in parallel** as Tasks with subagent_type="general-purpose" and model="opus". Each agent's prompt includes:
 
    - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `/pony-test-design`, `/pony-pbt-patterns`, `/pony-ref`), read that skill's content and include it in the agent prompt.
-   - Instructions to read `~/.claude/CLAUDE.md` and project CLAUDE.md (if one exists — not all projects have one; if absent, note it and proceed with global CLAUDE.md only) and follow those principles, including loading any skills they reference.
+   - The code-review principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project `CLAUDE.md` if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
    - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
    - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
    - For Correctness, Adversarial, and Tests personas: the captured build output and test results from step 2.
@@ -177,7 +177,7 @@ Pick whichever is most relevant to the change. If multiple conditions apply, pic
 4. **Spawn 3 persona agents in parallel** as Tasks with subagent_type="general-purpose" and model="opus". Each agent's prompt includes:
 
    - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `/pony-test-design`, `/pony-pbt-patterns`, `/pony-ref`), read that skill's content and include it in the agent prompt.
-   - Instructions to read `~/.claude/CLAUDE.md` and project CLAUDE.md (if one exists — not all projects have one; if absent, note it and proceed with global CLAUDE.md only) and follow those principles, including loading any skills they reference.
+   - The code-review principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project `CLAUDE.md` if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
    - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
    - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
    - The captured build output and test results from step 2 — always provided to Correctness and Adversarial. Also provided to Tests when it is the context-dependent persona.
@@ -295,5 +295,5 @@ The persona documents are in `personas/`. Full mode uses all 8; lightweight uses
 | `security.md` | Trust boundaries, injection, auth, resource bounds |
 | `performance.md` | Architectural bottlenecks, then local waste |
 | `tests.md` | Test quality, missing tests, counterfactual reasoning |
-| `principles.md` | Systematic CLAUDE.md audit with evidence |
+| `principles.md` | Systematic principles audit with evidence |
 | `wildcard.md` | Chaos agent — finds what the others miss |

--- a/pony-code-review/personas/adversarial.md
+++ b/pony-code-review/personas/adversarial.md
@@ -24,6 +24,6 @@ You try to break the code. You work backward from failure scenarios, not forward
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one
 - If a Pony project, load `/pony-ref` — capabilities, actor patterns, partial functions, and the mort pattern are especially relevant for constructing adversarial scenarios, but all sections provide context for finding failure modes
 - Read all changed files plus their callers and dependents — adversarial analysis requires understanding the broader system

--- a/pony-code-review/personas/api-design.md
+++ b/pony-code-review/personas/api-design.md
@@ -24,6 +24,6 @@ You evaluate the code from the consumer's perspective. How does it look to use, 
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md — especially code design principles
+- Review against the code-review principles provided in your prompt (especially the code design principles), and the project's `CLAUDE.md` if it has one
 - Read existing APIs in the project for pattern comparison
 - If a Pony project, load `/pony-ref` in full — the key patterns, common gotchas, composition patterns, and mort pattern sections are essential for evaluating whether code uses standard Pony patterns or reinvents degenerate versions. Also load `/pony-pbt-patterns` for test-related API patterns.

--- a/pony-code-review/personas/correctness.md
+++ b/pony-code-review/personas/correctness.md
@@ -24,6 +24,6 @@ You verify the code correctly implements its specification for valid inputs and 
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one
 - If a Pony project, load `/pony-ref` — the correctness pitfalls, capabilities table, and stdlib pitfalls sections are especially relevant, but the rest provides necessary context for evaluating correctness in Pony
 - Read the full source of all changed files, not just diffs — correctness depends on surrounding context

--- a/pony-code-review/personas/performance.md
+++ b/pony-code-review/personas/performance.md
@@ -24,6 +24,6 @@ You evaluate runtime efficiency and resource usage. You look at two levels: arch
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one
 - If a Pony project, load `/pony-ref` — the performance cheat sheet is especially relevant to your focus, but the rest provides essential context: capabilities affect what optimizations are possible, actor patterns affect concurrency design, and common gotchas include performance-relevant pitfalls. Don't tunnel-vision on the cheat sheet alone.
 - Identify hot paths from the call graph before judging severity

--- a/pony-code-review/personas/principles.md
+++ b/pony-code-review/personas/principles.md
@@ -4,7 +4,7 @@ You systematically verify the code against every applicable principle from the p
 
 ## Core Principles
 
-1. **Read both CLAUDE.md files completely.** `~/.claude/CLAUDE.md` (global) and the project CLAUDE.md. These are your source of truth. Do not work from memory of what they contain.
+1. **Use the principles provided to you.** The code-review principles are provided in your prompt, and the project may have its own `CLAUDE.md`. These are your source of truth. Do not work from memory of what they contain.
 
 2. **Enumerate applicable principles.** List every principle that applies to this change. A principle applies if the change touches code in its domain (e.g., testing principles apply if tests were changed or should have been changed).
 
@@ -24,6 +24,6 @@ You systematically verify the code against every applicable principle from the p
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md — this is the primary source material
+- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one — this is your primary source material
 - Read all changed files in full
 - Read any documentation files that the change might affect

--- a/pony-code-review/personas/security.md
+++ b/pony-code-review/personas/security.md
@@ -24,6 +24,6 @@ You look for vulnerabilities, unsafe patterns, and places where an attacker or u
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one
 - Identify the language and framework to focus on relevant vulnerability classes
 - Read all changed files plus any authentication/authorization code they interact with

--- a/pony-code-review/personas/tests.md
+++ b/pony-code-review/personas/tests.md
@@ -24,7 +24,7 @@ You evaluate whether the tests are meaningful and sufficient. A test suite that 
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one
 - `/pony-test-design` skill content (included by orchestrator)
 - If property tests are present or appropriate, `/pony-pbt-patterns` (included by orchestrator)
 - Read the test files AND the code they test — you can't evaluate test quality without understanding what's being tested

--- a/pony-code-review/personas/wildcard.md
+++ b/pony-code-review/personas/wildcard.md
@@ -24,6 +24,6 @@ These are not principles — you are deliberately unconstrained.
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one
 - Read all changed files in full
 - Read whatever else catches your attention — you are not constrained to specific files or skills

--- a/pony-code-review/references/principles.md
+++ b/pony-code-review/references/principles.md
@@ -1,0 +1,51 @@
+# Code Review Principles
+
+These are the code-design principles and code-change discipline this review audits against. They are a project-agnostic baseline — the standard a change is expected to meet regardless of language or domain.
+
+If the project under review has its own `CLAUDE.md` or other stated conventions, audit against those as well. Project conventions are usually more specific (naming schemes, file organization, architectural boundaries) and take precedence where they conflict with this baseline.
+
+## Code Design Principles
+
+1. **Prefer explicit over implicit**: When the language or framework allows something to work "by magic" (implicit conversions, convention-based wiring, unnamed dependencies), prefer the version that states what's happening directly. The cost of a few extra characters or lines is almost always less than the cost of someone later needing to reconstruct the hidden knowledge. Several principles below are specific applications of this idea.
+
+2. **Make illegal states unrepresentable**: Centralize validation at the construction boundary so the rest of the code can trust its inputs. Use the type system where strong (private constructors, factory methods returning error-or-value), conventions where weak. For complex types, separate the raw data shape from a validated wrapper (raw → validation → validated form); the rest of the system works with the validated form.
+
+3. **Errors are data, not exceptions**: Each layer should define its own error vocabulary as a concrete type (enum, union, sealed class). Higher-level errors wrap lower-level ones to preserve full context. Every error type should know how to describe itself as text. This gives exhaustive handling, no information loss during propagation, and clear error provenance.
+
+4. **Define separate types for each data boundary** (applications): In applications with multiple boundaries, user input, database records, and API responses should be distinct types even when they represent the same concept. A database record has an auto-generated ID; user input doesn't. Making these distinct prevents mixing concerns.
+
+5. **Default to immutability; use mutation deliberately and locally**: When performance demands mutation, confine it to the smallest possible scope. The rest of the system shouldn't know or care.
+
+6. **Prefer qualified/namespaced references**: Even when the language lets you import names unqualified, prefer namespaced references (e.g., `Module.foo` over `foo`). The cost of a few extra characters is outweighed by the clarity of knowing where something comes from and avoiding name collisions as the code grows.
+
+7. **Handle sensitive data deliberately**: When handling data, consider whether any of it is sensitive and, if so, how it should be handled. The answer may be redaction, encryption, masking, or something else depending on context. Sensitive-data handling should be a deliberate, explicit decision rather than an accident.
+
+8. **Separate domain logic from orchestration from presentation** (applications): In applications with distinct layers, domain types should have zero infrastructure dependencies. Orchestration combines domain logic with infrastructure (databases, caches). Presentation adapts orchestration for a specific protocol (HTTP, GraphQL, CLI).
+
+9. **Design for changeability, not for predicted changes**: Make designs modular and replaceable so future needs can be accommodated, but don't add abstractions, extension points, or features for changes that haven't happened yet. The goal is a design that's easy to modify, not one that anticipates specific modifications.
+
+10. **Type parameters in field types are not phantom**: When a type parameter appears only in stored field types (not in method signatures), it is still carrying type information through the pipeline. "Not mentioned in method bodies" does not mean "not needed." Before proposing to remove a type parameter, trace it to its terminal use — if it reaches a concrete type that depends on it, removing it loses compile-time guarantees.
+
+11. **Document coupling at the point of breakage**: When code A depends on the internal behavior of code B (read sequence, execution order, size assumptions), put the comment on B — that's where a future maintainer would make a breaking change. Commenting at A ("we depend on B") doesn't help because the person changing B won't be reading A.
+
+12. **Distinct semantics deserve distinct representations**: When two values have different meanings or different handling semantics, represent them as separate types even when one could technically serve for both. Overloading a single type to carry multiple meanings forces callers to use out-of-band knowledge to distinguish them.
+
+13. **It is easier to give than take away**: When deciding whether to include something in an API (a callback, a parameter, a feature), lean toward omitting it. You can always add it later if needed, but removing it is a breaking change. Start minimal; expand based on demonstrated need.
+
+14. **Don't patch around architectural problems**: When a remaining gap can't be fixed cleanly at the current layer, say so and stop. Don't write special-case workarounds for problems that need deeper fixes. If a fix requires assumptions about the internal structure of a different layer, it belongs in that layer. The bias toward producing a visible result ("I fixed this too!") leads to fragile code that papers over the real issue and makes the eventual proper fix harder to reason about.
+
+15. **Trait/interface defaults only for universal invariants**: A default implementation should express behavior that's correct for every inheritor. If the correct behavior depends on which concrete type is implementing, make the method abstract at that level and push defaults down to intermediate traits or concrete types where a universal invariant actually holds. "Flip the default and add override-backs" hides state-dependent decisions behind inheritance semantics. Applies to any language with trait/interface/mixin defaults.
+
+## Code Change Discipline
+
+**Evaluate copied patterns, don't cargo-cult them**: When reusing a pattern from existing code, copy the *intent*, not the *incidental choices*. Ask: "Does the new usage actually need each piece of this?" Strip it down to what's required, then add back only what's justified. Conventions (legal headers, naming schemes, file organization) should be followed for consistency. Technical patterns (error handling, data structures) should be evaluated on merit. The presence of a pattern across *all* files suggests convention.
+
+**Don't split lines unnecessarily**: Only break a line when it exceeds the project's line limit (typically 80 columns). Splitting lines that fit makes code harder to scan. This applies equally to code, docstrings, and comments — use the available width, don't wrap at 50 columns when 80 is the limit. The 80-column rule applies to code, not prose — markdown files should flow naturally, breaking only on paragraph boundaries.
+
+**Consistency across repetitive structure**: When code implements the same pattern across multiple variants (type families, format handlers, similar APIs), quality tends to taper — the first variant gets careful attention, later ones get less. When writing, check that the last variant got the same rigor as the first. This especially applies to tests: if the first type family has boundary tests at every transition point, every other type family should too. When reviewing, compare thoroughness across variants; inconsistency is a smell.
+
+**Document public API elements**: Every public-facing API element (primitives, classes, actors, traits, interfaces, and their public methods) should have a docstring. This is part of "done" — don't wait for a reviewer to ask. Internal/private elements don't need docstrings unless the logic is non-obvious.
+
+**Fix what your change makes stale**: When a change invalidates something elsewhere — a comment, a docstring, a test description, documentation, a configuration reference — fix it in the same PR. Stale artifacts left behind are bugs in the making, and "I didn't modify that line" isn't an excuse when your change is what made it wrong.
+
+**Bulk renaming: verify substring safety before a global replace**: Check whether the target string appears as a substring of other identifiers in the file (e.g., `JsonConverter` inside `RepositoryJsonConverter`). Use contextual patterns that include surrounding syntax so the match is unambiguous. Only use a global replace for identifiers that don't appear as substrings of any other name in scope.


### PR DESCRIPTION
The code review skill was pointing at my personal CLAUDE.md to get information which made it perform "subpar" when others used it.