### PR TITLE
Add project CLAUDE.md with the changelog-PR description convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Pony LLM Skills — project instructions
+
+Instructions for working in this repository.
+
+## Pull requests
+
+**On a changelog-labeled PR, write the description like a release note.** A PR carrying a `changelog - *` label documents a user-facing change, and the generated CHANGELOG entry links readers straight to the PR — so the PR description is what a reader lands on. Write it for the person *using* the skills, not for someone reading the implementation: plain language, the user-visible impact, and why it matters — not an enumeration of the internal mechanics. Keep it short. (Example — PR #36's description read: The code review skill was pointing at my personal CLAUDE.md to get information which made it perform "subpar" when others used it.)


### PR DESCRIPTION
The repository had no project CLAUDE.md. This adds one documenting that
a PR carrying a changelog label should have an end-user-facing
description: the generated CHANGELOG entry links readers straight to the
PR, so the description is what they land on. Internal/process change, so
this PR gets no changelog label.
