### PR TITLE
Remove pony-test-design's dependency on the author's global CLAUDE.md

### DIFF
--- a/pony-test-design/personas/evaluation/counterfactual.md
+++ b/pony-test-design/personas/evaluation/counterfactual.md
@@ -47,7 +47,7 @@ assertion, see if it fires), catching weak tests before they're implemented.
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
 - Read the candidate test strategy from Stage 1 synthesis
 - Read the code under test — you need to construct plausible mutations
 - If a Pony project, load `/pony-ref`

--- a/pony-test-design/personas/evaluation/coverage.md
+++ b/pony-test-design/personas/evaluation/coverage.md
@@ -46,7 +46,7 @@ provides false confidence — the parts that aren't tested are where bugs hide.
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
 - Read the candidate test strategy from Stage 1 synthesis
 - Read the code under test — you need the decision space to assess coverage
 - If a Pony project, load `/pony-ref`

--- a/pony-test-design/personas/evaluation/property-opportunity.md
+++ b/pony-test-design/personas/evaluation/property-opportunity.md
@@ -53,7 +53,7 @@ to find those invariants and recommend properties.
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
 - Read the candidate test strategy from Stage 1 synthesis
 - Read the code under test — you need to identify invariants
 - Load `/pony-pbt-patterns` for generator design and coverage patterns

--- a/pony-test-design/personas/evaluation/specificity.md
+++ b/pony-test-design/personas/evaluation/specificity.md
@@ -45,7 +45,7 @@ verify it reaches the developer's code, not just library functions.
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
 - Read the candidate test strategy from Stage 1 synthesis
 - Read the code under test — you need to trace execution paths
 - If a Pony project, load `/pony-ref`

--- a/pony-test-design/personas/evaluation/wildcard.md
+++ b/pony-test-design/personas/evaluation/wildcard.md
@@ -50,7 +50,7 @@ These are not principles — you are deliberately unconstrained.
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
 - Read the candidate test strategy from Stage 1 synthesis
 - Read whatever else catches your attention — you are not constrained to
   specific files or skills

--- a/pony-test-design/personas/planning/boundary-focused.md
+++ b/pony-test-design/personas/planning/boundary-focused.md
@@ -38,7 +38,7 @@ actually does, not what it's supposed to do.
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
 - Read all pony-test-design disciplines in SKILL.md — they all apply
 - Read the code under test — you need the implementation to map boundaries
 - If a Pony project, load `/pony-ref`

--- a/pony-test-design/personas/planning/contract-focused.md
+++ b/pony-test-design/personas/planning/contract-focused.md
@@ -56,7 +56,7 @@ bring is the outside-in perspective.
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
 - Read all pony-test-design disciplines in SKILL.md — they all apply
 - Read the public API of the code under test — types, signatures, docstrings
 - Do NOT read the implementation until after planning (step 7)

--- a/pony-test-design/personas/planning/failure-focused.md
+++ b/pony-test-design/personas/planning/failure-focused.md
@@ -43,7 +43,7 @@ paths.
 
 ## Context Loading
 
-- Read `~/.claude/CLAUDE.md` and project CLAUDE.md
+- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
 - Read all pony-test-design disciplines in SKILL.md — they all apply
 - Read the code under test — you need to understand what can go wrong
 - Read any error types or error handling patterns in the codebase


### PR DESCRIPTION
The personas read the author's global CLAUDE.md for general code-design principles, which are tangential to test design — the testing disciplines live in this skill's own SKILL.md — and absent on any non-author machine. This drops that read and keeps the project CLAUDE.md read, making the skill self-contained.
