### PR TITLE
Meta-skill that can adding routing for agents to all the skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ This only removes the symlinks, not the cloned repo.
 
 ## Skills
 
+### Routing
+
+#### pony-skills
+
+A routing index for the other skills — load it with `/pony-skills` (or reference it from a Pony project's `CLAUDE.md`) and it tells you which `pony-*` skill to load for each task. The single-trigger alternative to wiring up each skill's trigger by hand; a good place to start.
+
 ### Pony Language
 
 #### pony-ref
@@ -150,7 +156,13 @@ This is infrastructure — loaded by `pony-ensemble` during the synthesis step.
 
 ## Suggested Triggers
 
-Add these to your `CLAUDE.md` or `AGENTS.md` to load skills automatically when relevant:
+Add these to your `CLAUDE.md` or `AGENTS.md` to load skills automatically when relevant. Two ways to do it: load the `pony-skills` routing index with a single trigger that covers all of them, or add individual triggers for just the skills you want.
+
+### /pony-skills
+
+> **Load `/pony-skills` at the start of Pony work**: At the start of work in a Pony project, load the `pony-skills` skill — a routing index that tells you which `pony-*` skill to load for each task. This one trigger covers all of the skills below.
+
+Prefer to pick individually? Add any of these instead:
 
 ### /pony-ref
 

--- a/pony-skills/SKILL.md
+++ b/pony-skills/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: pony-skills
+description: Routing index for the Pony skills — tells you which pony-* skill to load for each task, and when. Load at the start of work in a Pony project.
+disable-model-invocation: false
+---
+
+# Pony Skills
+
+When one of these applies, load the named skill.
+
+| When | Load |
+|---|---|
+| Working on Pony at all — before you start, and for questions about capabilities, the type system, the runtime, or testing | `pony-ref` |
+| Designing APIs, types, features, or system boundaries (not just implementing an existing design) | `pony-software-design` |
+| Reviewing code, or before opening a PR | `pony-code-review` |
+| Writing tests, or assessing test quality | `pony-test-design` |
+| Writing property-based or generative tests | `pony-pbt-patterns` |
+| Before forming a hypothesis about a non-trivial bug | `pony-debug` |
+| Making a user-facing change in a released project (VERSION is not `0.0.0`) | `pony-release-notes` |
+| Writing or updating a library's README | `pony-library-readme` |
+| Adding, updating, or reorganizing examples | `pony-examples-readme` |
+| Running the ensemble workflow (on request) | `pony-ensemble` |


### PR DESCRIPTION
A new `pony-skills` skill: a routing index that tells you which Pony skill to reach for at each step. Load it (or reference it from your project's `CLAUDE.md`) instead of wiring up — or remembering — each skill's trigger by hand.
