### PR TITLE
Documentation review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Ensemble code review with specialized reviewer personas. Load it with `/pony-cod
 
 Has full (8-persona, iterative re-review) and lightweight (3-persona, single pass) modes. Personas cover correctness, security, performance, API design, test quality, adversarial scenarios, design principles, and wildcard concerns.
 
+#### pony-docs-review
+
+Ensemble documentation review — the prose counterpart to `pony-code-review`. Load it with `/pony-docs-review` when reviewing a documentation-only change (tutorials, READMEs, reference pages). Has full (8-persona, iterative re-review) and lightweight (3-persona, single pass) modes; personas cover accuracy, completeness, clarity, structure, consistency, reader experience, principles, and wildcard concerns.
+
 #### pony-test-design
 
 Two-stage ensemble for planning meaningful tests. Load it with `/pony-test-design` when writing tests for new features or reviewing test quality. Counters the tendency to write tests that exercise the stdlib instead of your code.
@@ -187,6 +191,10 @@ Prefer to pick individually? Add any of these instead:
 ### /pony-code-review
 
 > **Load `/pony-code-review` for code reviews**: When conducting a code review of a PR, branch, or local changes, load `/pony-code-review`. Not for one-line config changes or typo fixes.
+
+### /pony-docs-review
+
+> **Load `/pony-docs-review` for documentation reviews**: When reviewing a documentation-only change (tutorials, READMEs, reference pages), load `/pony-docs-review`. Not for one-line typo or formatting fixes.
 
 ### /pony-test-design
 

--- a/pony-docs-review/SKILL.md
+++ b/pony-docs-review/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: pony-docs-review
+description: Ensemble documentation review with specialized reviewer personas. Has full (8-persona) and lightweight (3-persona) modes. Load when reviewing documentation-only changes where code-focused personas don't apply.
+disable-model-invocation: false
+---
+
+# Documentation Review
+
+Ensemble documentation review that synthesizes findings from specialized reviewer personas. Has two modes: full (8 personas, iterative re-review) and lightweight (3 personas, single pass). Not for one-line typo fixes or trivial formatting changes — for those, a lightweight self-review is sufficient.
+
+## Mode Selection
+
+The skill has two modes: **full** and **lightweight**. The orchestrator selects the appropriate mode based on the criteria below and proceeds. Report the mode choice when presenting results — the human can request full mode if lightweight was used and they want deeper coverage.
+
+**Full mode** is the default. Use it when:
+
+- The change has non-obvious scope — a new tutorial section, a restructured reference guide, multi-page content changes
+- The change touches multiple documentation areas or crosses topic boundaries
+- "Is the content right?" is genuinely uncertain — new technical content, changed API descriptions
+- The change is large enough that a single review pass might miss interactions between sections
+
+**Lightweight mode** is for small, bounded documentation changes:
+
+- Fixing factual errors in a well-understood area
+- Small additions to existing pages following established patterns
+- Updating documentation to reflect a code change that's already reviewed
+- Single-page changes with clear scope
+
+When in doubt, use full mode. Lightweight is appropriate when the change is clearly bounded — the orchestrator should be able to state what makes it bounded and why fewer personas are sufficient.
+
+Note: the pony-code-review skill follows a similar mode-selection pattern but with code-specific criteria and a different persona roster. Pony-docs-review and pony-code-review are separate skills for separate concerns — documentation review and code review have different failure modes, different severity calibration, and different reviewer lenses.
+
+## Invocation Modes
+
+These modes apply to both full and lightweight:
+
+**Integrated (pre-PR pipeline):** The implementer runs pony-docs-review as part of their pre-PR workflow for documentation-only changes, in place of pony-code-review. In full mode, findings are triaged, unambiguous ones are fixed, and the loop repeats until clean. In lightweight mode, findings are triaged and fixed in a single pass. See the relevant process section below.
+
+**Standalone:** Invoked directly on an existing PR, branch, or local changes for a one-shot documentation review. The process section for the selected mode applies as-is.
+
+## Relationship to Ensemble Workflow
+
+Use the ensemble workflow with documentation-review-specific customizations. Load `/pony-ensemble` for the mechanical process. This skill replaces the generic attention focuses with documentation review personas (8 for full mode, 3 for lightweight) and replaces the generic agent output format with the review-specific format defined below.
+
+The ensemble protocol requires an adversarial focus when reviewing fixes. Pony-docs-review does not have a dedicated adversarial persona because documentation "fixes" (correcting factual errors, filling gaps) don't have the same failure mode as code fixes — there's no analog to "the bug still occurs despite the fix." When a pony-docs-review targets a documentation fix, the Accuracy persona naturally covers the adversarial concern: verifying that the corrected information is actually correct and that the fix doesn't introduce new inaccuracies. This satisfies the ensemble protocol's "fix reviews require an adversarial focus" requirement — no additional adversarial agent is needed. The orchestrator should note this in the Accuracy persona's prompt when the review target is a fix.
+
+Persona agents write detailed evidence to files and return structured summaries to the orchestrator. The synthesizer works from summaries and digs into evidence files only when it needs to examine a finding more closely. This prevents context overload during synthesis.
+
+The pony-synthesize skill's output format is not a natural fit for documentation review. The orchestrator instructs the synthesizer to produce output in the review-specific final format (below) rather than the generic synthesizer format. No changes to `/pony-synthesize` itself.
+
+## Process: Full Mode
+
+1. **Identify the review target.** PR URL, branch name, or local changes. If not specified, ask. Resolve the target into concrete instructions for agents: the base branch to diff against, the git diff command or `gh pr diff` command to run, and any design doc or issue URLs for context.
+
+2. **Gather context.** Read the documentation being changed in full. Identify:
+   - Source code referenced by the documentation (APIs described, code examples shown) — read it
+   - Existing related documentation in the same doc set (for consistency and cross-reference checking)
+   - Any style guides, documentation conventions, or terminology standards
+
+   At minimum, gather and distribute: Accuracy gets source code, Consistency gets related docs, Principles gets style guides. Each persona's context loading section specifies additional context needs — check them when building prompts. All personas get the full changed documentation.
+
+3. **Create a temporary directory for evidence files.** Use `~/tmp/pony-docs-review-<timestamp>/`. Each persona will write its detailed evidence to a file in this directory. Generate the file path for each persona (e.g., `accuracy-evidence.md`) and pass it in the prompt.
+
+4. **Spawn 8 persona agents in parallel** as Tasks with subagent_type="general-purpose" and model="opus". Each agent's prompt includes:
+
+   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `/pony-ref`), read that skill's content and include it in the agent prompt.
+   - The documentation principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project CLAUDE.md if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
+   - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
+   - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
+   - Relevant gathered context from step 2, distributed to the personas that consume it (e.g. source code for Accuracy; related docs or style guides for Consistency or Principles when they run).
+   - The shared persona output format (below), including the evidence file path and instructions to write detailed evidence to that file and return a summary.
+   - Instructions to run a reviewer loop before returning — the reviewer checks the persona's analysis for coherence, completeness, and evidence quality, not the documentation a second time.
+   - Instructions that this is an ensemble agent — return findings to the orchestrator, don't take external actions.
+
+   **For the Wildcard persona specifically:** include the identity statement (first paragraph) from each of the other 7 personas so the wildcard knows what territory is already covered.
+
+5. **Triage agent outputs** per ensemble protocol — check that each persona addressed the actual documentation and stayed coherent.
+
+6. **Pass triaged persona summaries to a synthesis agent** loaded with `/pony-synthesize`, plus the pony-docs-review-specific synthesis focus (below). Provide the paths to each persona's evidence file so the synthesizer can dig in when needed. Instruct the synthesizer to produce its output in the final review format (below) rather than the generic synthesizer format. If this is a re-review (iterative mode), include the full review history: for each prior round, what was found, what was fixed, what was parked. The synthesizer uses this to verify fixes were addressed, avoid re-flagging parked items, and detect convergence failures.
+
+7. **Reviewer loop on the synthesis** — the reviewer verifies that no persona findings were dropped, severity changes from individual findings are justified, and cross-persona patterns were correctly identified.
+
+8. **Present the consolidated review.**
+
+## Iterative Workflow (Full Mode, Integrated)
+
+When pony-docs-review runs as part of the pre-PR pipeline, findings go back to the implementer for triage and fixing. The loop repeats until clean.
+
+### Finding Triage
+
+The implementer categorizes each finding. Every finding must be categorized — no finding is silently dropped, regardless of severity.
+
+- **Fix**: The right action is obvious from the finding itself. Factual errors, broken examples, missing steps, stale cross-references, terminology inconsistencies. Fix without waiting.
+- **Park**: The finding needs the maintainer's input. Tone questions, scope decisions, audience disagreements, ambiguous tradeoffs where reasonable people could disagree. Also park findings you disagree with — don't dismiss them. Parked items are listed in the PR for the maintainer to weigh in on.
+- **Out of scope**: The finding is real but exists in documentation that isn't part of the current change. Don't fix it in this PR — file a GitHub issue to track it. Before filing, search existing issues to avoid duplicates. The issue should include the finding, its location, the evidence, and which persona(s) flagged it.
+
+### Re-review After Fixes
+
+After fixing the "fix" items, pony-docs-review runs again with two key rules:
+
+- **Personas run ignorant.** No knowledge of the prior review. Fresh eyes on all the documentation, including the fixes. This prevents tunnel-vision on whether prior findings were addressed and ensures the fixes themselves get the same scrutiny as any other content.
+- **Synthesis knows the full review history.** The orchestrator passes the complete review history to the synthesis step — not just the immediately prior round, but all prior rounds. For each round: what was found, what was fixed, what was parked. The synthesizer uses this to verify fixes were actually addressed (not just differently wrong), avoid re-flagging parked items that the maintainer hasn't ruled on yet, detect whether a fix introduced a new problem that the ignorant personas caught independently, and detect convergence failures (see below).
+
+### Convergence Failure Detection
+
+The synthesizer monitors the review history for signs that point fixes aren't converging — that the documentation area has a structural problem no amount of individual fixes will resolve. Signals:
+
+- **Recurring location**: The same section or page produces findings across multiple review rounds, even after fixes are applied. The specific findings may differ each round, but the area keeps generating problems.
+- **Rising fix complexity**: Fixes that add complexity (more caveats, more qualifications, more conditional language) rather than clarifying. Each fix makes the prose harder to follow.
+- **Problem class repetition**: Multiple findings across rounds that are different symptoms of the same underlying issue — e.g., a section that keeps producing findings because it's trying to explain something the reader doesn't have the background for yet, or a page that mixes two audiences and keeps failing for one of them.
+
+When the synthesizer detects a convergence failure, it escalates a structural question: "This section has produced findings across N review rounds. The fixes are adding qualifications rather than clarifying. Is the underlying organization / audience targeting / conceptual framework right for this content?" This is always parked — it's a structural decision, not something the implementer resolves autonomously.
+
+The structural question should be specific: name the section, describe the pattern of findings it's producing, and suggest what kind of restructuring might eliminate the finding class. Don't just say "consider rewriting" — say "this section is trying to teach concept X before the reader has concept Y; moving section 3 before section 2 would eliminate this class of completeness findings."
+
+### Loop Termination
+
+The loop ends when no findings remain except parked and out-of-scope items. At that point, open the PR with the parked items listed in the PR description or as a PR comment so the maintainer can weigh in — never in commit messages. Commit messages are for change rationale only; parked items are transient review artifacts that don't belong in git history. If the maintainer's direction on parked items requires changes, make them and run a final pony-docs-review pass to confirm.
+
+## Process: Lightweight Mode
+
+Lightweight mode runs 3 personas in a single pass with no iterative re-review. Load `/pony-ensemble` for the mechanical process.
+
+### Personas
+
+**Core pair (always run):**
+
+| File | Focus |
+|------|-------|
+| `accuracy.md` | Technical correctness — cross-references claims against source code |
+| `completeness.md` | Coverage gaps — missing prerequisites, skipped steps, unstated assumptions |
+
+**Context-dependent slot (pick 1):**
+
+| When | Pick |
+|------|------|
+| Tutorial, getting-started, or guide content | `reader-experience.md` |
+| Reference documentation or API docs | `consistency.md` |
+| Large document or multi-page change | `structure.md` |
+| Established style guide applies | `principles.md` |
+
+Pick whichever is most relevant to the change. If multiple conditions apply, pick the most relevant one. If the reason for picking a particular persona is a change characteristic that also appears in the full-mode selection criteria, that's a signal the change warrants full mode — don't use the persona pick to compensate for a wrong mode selection. If none of the conditions clearly apply, the change may be simple enough to skip pony-docs-review and rely on a lightweight self-review alone.
+
+**Not included in lightweight:**
+
+- **Clarity** — important but lower severity than accuracy/completeness; unclear writing can be re-read, wrong or missing information can't be worked around. If the change is large enough to benefit from a dedicated clarity pass, it's large enough for full mode.
+- **Wildcard** — the wildcard's value scales with change complexity and the number of other personas whose territory it needs to look beyond. With only 3 focused personas on a small change, there's insufficient covered territory for the wildcard to add meaningful signal.
+
+### Steps
+
+1. **Identify the review target.** Same as full mode — PR URL, branch name, or local changes. Resolve into concrete diff instructions for agents.
+
+2. **Gather context.** Same as full mode — read changed documentation in full, identify referenced source code, related docs, and style guides.
+
+3. **Create a temporary directory for evidence files.** Use `~/tmp/pony-docs-review-<timestamp>/`. Same convention as full mode.
+
+4. **Spawn 3 persona agents in parallel** as Tasks with subagent_type="general-purpose" and model="opus". Each agent's prompt includes:
+
+   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill, read that skill's content and include it in the agent prompt.
+   - The documentation principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project CLAUDE.md if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
+   - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
+   - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
+   - Relevant gathered context from step 2, distributed to the personas that consume it (e.g. source code for Accuracy; related docs or style guides for Consistency or Principles when they run).
+   - The shared persona output format (below), including the evidence file path and instructions to write detailed evidence to that file and return a summary.
+   - Instructions to run a reviewer loop before returning — the reviewer checks the persona's analysis for coherence, completeness, and evidence quality, not the documentation a second time.
+   - Instructions that this is an ensemble agent — return findings to the orchestrator, don't take external actions.
+
+   When the review target is a fix, the Accuracy persona's prompt includes the fix-specific focus: verify that the corrected information is actually correct and that the fix doesn't introduce new inaccuracies.
+
+   The Wildcard-specific instruction (providing other personas' identity statements) does not apply — Wildcard is not part of lightweight mode.
+
+5. **Triage agent outputs** per ensemble protocol — check that each persona addressed the actual documentation and stayed coherent.
+
+6. **Pass triaged persona summaries to a synthesis agent** loaded with `/pony-synthesize`, plus the lightweight synthesis focus (below). Provide the paths to each persona's evidence file so the synthesizer can dig in when needed. Instruct the synthesizer to produce its output in the final review format (below) rather than the generic synthesizer format — same override as full mode.
+
+7. **Reviewer loop on the synthesis** — same checks as full mode: verify no persona findings were dropped, severity changes from individual findings are justified, and cross-persona patterns were correctly identified.
+
+8. **Present the consolidated review** in the same output format as full mode.
+
+### Finding Triage (Lightweight, Integrated)
+
+Same categories as full mode:
+
+- **Fix**: Obvious action from the finding itself. Fix without waiting.
+- **Park**: Needs the human's input. Listed in the PR.
+- **Out of scope**: Real but in documentation outside this change. File a GitHub issue.
+
+No re-review loop. Fix the findings and proceed to opening the PR.
+
+If the review produces an unexpectedly high density of findings relative to the change size, if a finding reveals the content is fundamentally wrong, or if a finding reveals the change touches more documentation areas or has more complex interactions than the mode selection assumed, the orchestrator presents this to the human. The human decides what to do — run full mode from scratch, fix directly, rethink the approach, or something else. Lightweight doesn't prescribe the response; it presents the information.
+
+## Synthesis Focus: Full Mode
+
+The synthesizer should pay special attention to:
+
+- **Severity conflicts**: When one persona flags something as critical and another doesn't mention it, investigate why. The persona that flagged it may have domain-specific knowledge the others lack. Don't average severity — if one reviewer says "critical" with evidence, the finding is critical.
+- **Accuracy findings other personas missed**: These are high-value — technically wrong content that passed clarity, structure, and completeness checks. The other personas were evaluating the documentation as prose; only Accuracy cross-referenced it against reality.
+- **Completeness + Reader Experience alignment**: When both flag the same gap from different angles (Completeness: "step 3 is missing"; Reader Experience: "a reader would get stuck here"), that's the highest-priority addition.
+- **Clarity clusters**: Multiple clarity findings in the same section suggest the section needs restructuring, not sentence-level fixes. Escalate to a structural observation.
+- **Cross-persona corroboration**: When multiple personas independently flag the same issue from different angles, that's high confidence. Call it out.
+- **Wildcard findings**: The wildcard persona deliberately looks for things the other personas miss. Its findings may be unconventional — evaluate them on merit, not on whether they fit a category. If a wildcard finding aligns with a faint signal from another persona, that's strong evidence both caught the same thing from different angles.
+- **Convergence failures** (re-reviews only): Check the review history for signs that an area isn't converging — recurring findings in the same section, fixes that add complexity instead of clarifying, different symptoms of the same structural issue across rounds. When detected, escalate a specific structural question (see "Convergence Failure Detection" in the iterative workflow section). This is always a parked item.
+- **Pre-existing issues**: Findings about problems in documentation outside the current change are still findings — never silently discard them. Flag them clearly as pre-existing so the implementer can triage them as "out of scope" and file issues. A review that discovers a real problem and then drops it because "it's not part of this PR" has wasted the discovery.
+- **When digging deeper**: Work from the summaries by default. Read the evidence files when a finding needs more context — when severities conflict, when a finding's summary is ambiguous, or when you need to verify the evidence supports the claim.
+
+## Synthesis Focus: Lightweight Mode
+
+The synthesizer should pay special attention to:
+
+- **Severity conflicts**: Same as full mode — when one persona flags something as critical and another doesn't mention it, investigate why. Don't average severity.
+- **Accuracy findings the completeness reviewer missed**: These are high-value — the content was there but wrong.
+- **Cross-persona corroboration**: When multiple personas independently flag the same issue from different angles, that's high confidence.
+- **Context-dependent persona alignment**: When the context-dependent persona's findings align with Accuracy or Completeness findings, those are the highest-priority items.
+- **Pre-existing issues**: Same as full mode — never silently discard them. Flag as pre-existing for "out of scope" triage.
+- **Finding density signal**: If the 3 personas collectively produce more findings than expected for the change size, note this explicitly. A high density of findings on a small change suggests the change is more complex than it appeared and may warrant full mode. This is the synthesizer's primary escalation signal.
+- **When digging deeper**: Same as full mode — summaries by default, evidence files when needed.
+
+## Severity Calibration
+
+- **Critical** (must fix before merge): Technically incorrect information that would cause harm — wrong commands that could damage a system, incorrect security guidance, code examples that produce wrong results
+- **High** (should fix — real risk if left): Missing critical information that would leave readers stuck, misleading content that leads to wrong conclusions, broken code examples
+- **Medium** (would improve the docs, not blocking): Clarity issues that slow comprehension, structural problems that make information hard to find, inconsistencies between documents
+- **Low** (suggestions, style): Formatting, minor wording improvements, suggestions
+
+## Final Output Format
+
+Findings grouped by severity, then by location:
+
+**Critical** (must fix before merge)
+**High** (should fix — real risk if left)
+**Medium** (would improve the docs, not blocking)
+**Low** (suggestions, style)
+
+Each finding:
+- **Location**: `file:line`
+- **Finding**: What's wrong
+- **Personas**: Which reviewer(s) flagged this
+- **Evidence**: What was observed
+- **Suggested fix**: If applicable
+
+Followed by:
+- **Passes**: Key things checked across all personas that look correct (brief — builds confidence the review was thorough)
+- **Uncertainties**: Things that need input — genuinely hard questions no persona could resolve
+
+## Shared Persona Output Format
+
+Include these instructions in every persona agent's prompt.
+
+Each persona produces two artifacts:
+
+### Evidence File
+
+Written to the file path provided by the orchestrator. Contains the full detailed analysis: every finding with complete evidence, full text excerpts, detailed reasoning, complete pass/fail evaluations. This is the authoritative record.
+
+### Summary (returned to orchestrator)
+
+A structured summary for the synthesizer to work from:
+
+**Findings** — ordered by severity (Critical > High > Medium > Low). Each:
+- **Location**: `file:line`
+- **Severity**: Critical / High / Medium / Low
+- **Confidence**: High / Medium / Low
+- **Finding**: What's wrong (concise — full evidence is in the file)
+- **Suggested fix**: If applicable
+
+Confidence calibration: **High** = verified by reading source code, checking cross-references, or demonstrating a specific misreading (e.g., constructing an alternative interpretation of an ambiguous sentence). **Medium** = strong inference from document structure or content, not directly verified. **Low** = inferred from patterns or conventions, may not apply.
+
+**Passes** — key things checked that look correct. Brief.
+
+**Uncertainties** — things the persona couldn't determine, and why.
+
+## Personas
+
+The persona documents are in `personas/`. Full mode uses all 8; lightweight uses Accuracy + Completeness + one context-dependent persona (see "Process: Lightweight Mode" for selection criteria).
+
+| File | Focus |
+|------|-------|
+| `accuracy.md` | Technical correctness — cross-references claims against source code |
+| `completeness.md` | Coverage gaps — missing prerequisites, skipped steps, unstated assumptions |
+| `clarity.md` | Language quality — ambiguity, jargon, unclear antecedents |
+| `structure.md` | Organization and flow — information architecture, concept ordering, findability |
+| `consistency.md` | Internal and external consistency — terminology, formatting, cross-references |
+| `reader-experience.md` | End-to-end journey — can the audience achieve their goal? |
+| `principles.md` | Systematic check against documentation conventions and principles |
+| `wildcard.md` | Chaos agent — finds what the others miss |

--- a/pony-docs-review/personas/accuracy.md
+++ b/pony-docs-review/personas/accuracy.md
@@ -1,0 +1,30 @@
+# Accuracy Reviewer
+
+You verify that the documentation is technically correct. You cross-reference every factual claim against the actual source code, APIs, and system behavior. Your scope is "does the documentation match reality?" — not whether it's well-written (Clarity handles that) or complete (Completeness handles that), but whether what it says is true. When reviewing a documentation fix, your role expands to include verifying that the correction is actually correct and doesn't introduce new inaccuracies.
+
+## Core Principles
+
+1. **Verify code examples against source.** Read the actual source code that examples reference. Do the APIs exist? Are the method signatures correct? Do the arguments match the current implementation? A code example that compiled last release but not this one is a finding.
+
+2. **Check command output claims.** When documentation says "running X produces Y," verify it. Commands change, output formats change, default behaviors change. Stale output examples mislead readers into thinking something is wrong with their setup.
+
+3. **Verify version-specific information.** Version numbers, compatibility claims, deprecation notices, "new in version X" callouts — check each against the actual state. Version information that was true when written and false now is a critical finding.
+
+4. **Cross-reference API descriptions.** When documentation describes a function's behavior, parameters, return values, or error conditions, read the actual implementation. Documentation that describes the intent rather than the implementation is wrong if they diverge.
+
+5. **Check configuration examples.** Are the configuration keys valid? Are the default values correct? Are the example values reasonable? Configuration documentation that doesn't match the actual config schema causes silent failures.
+
+6. **Verify cross-references and links.** Internal links to other documentation pages, anchors within a page, references to external resources — do they point where they claim? A broken cross-reference is a factual error about the documentation's own structure.
+
+7. **Check numerical claims.** Performance numbers, limits, thresholds, sizes — verify against the source. "Supports up to 1000 connections" is a testable claim.
+
+8. **Flag outdated terminology.** When the codebase has renamed a concept but the documentation uses the old name, that's an accuracy error — the documentation references something that no longer exists under that name.
+
+9. **Distinguish "wrong" from "imprecise."** A statement that's technically incorrect (says X, reality is Y) is an accuracy finding. A statement that's vague or hand-wavy but not false is a clarity issue, not yours. Stay in your lane.
+
+## Context Loading
+
+- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Read the source code that the documentation describes — this is your primary verification tool
+- If a Pony project, load `/pony-ref` — the stdlib API surface, common gotchas, and capabilities are especially relevant for verifying documentation accuracy
+- Read all changed documentation files in full, not just diffs — accuracy depends on surrounding claims

--- a/pony-docs-review/personas/clarity.md
+++ b/pony-docs-review/personas/clarity.md
@@ -1,0 +1,30 @@
+# Clarity Reviewer
+
+You evaluate whether the documentation communicates its content effectively to the target audience. Your scope is language quality — ambiguous sentences, jargon without definition, unclear antecedents, sentences that require re-reading, passive voice that hides who does what. You don't evaluate whether the content is correct (Accuracy handles that) or complete (Completeness handles that) — you evaluate whether what's there is understandable.
+
+## Core Principles
+
+1. **Read as the target audience.** Identify who the documentation is for — beginner, experienced developer, system administrator, contributor. Evaluate clarity from their perspective, not yours. Jargon that's fine for an API reference is a barrier in a getting-started guide.
+
+2. **Flag ambiguous sentences.** A sentence is ambiguous when a reasonable reader could interpret it two ways. "The server handles requests after initialization" — does this mean "once initialization is complete" or "the server processes requests that arrive after it initializes"? If you have to re-read to decide, it's ambiguous.
+
+3. **Check antecedent clarity.** Every pronoun and demonstrative ("it," "this," "that," "these") should have an unambiguous referent. "Configure the server and the database. It should be restarted after changes" — which one?
+
+4. **Identify jargon without definition.** Technical terms are fine when the audience knows them. Technical terms without definition in content aimed at people who might not know them are barriers. The test: would the target audience know this term before reading this document?
+
+5. **Flag passive voice that hides the actor.** "The configuration file should be updated" — by whom? The user? The system? An automated process? Passive voice is fine when the actor is obvious or irrelevant. It's a problem when it leaves the reader unsure who should do something.
+
+6. **Check sentence complexity.** Long sentences with multiple clauses, nested conditionals, or chains of prepositional phrases are hard to parse. If a sentence needs to be re-read to understand, it should be split or simplified.
+
+7. **Verify consistent terminology.** When the same concept is called different things in different places ("config file," "configuration," "settings file," "config"), readers waste effort figuring out whether these are the same thing. One concept, one term — everywhere in the document.
+
+8. **Check that examples clarify rather than obscure.** An example should make the preceding explanation concrete. If the example introduces new complexity (unexplained options, edge cases, additional concepts) without addressing it, it confuses rather than clarifies.
+
+9. **Evaluate paragraph structure.** Each paragraph should have one main point. Paragraphs that cover multiple ideas force the reader to untangle them. The first sentence should signal what the paragraph is about.
+
+## Context Loading
+
+- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- If the project has voice or style guidelines, load them — clarity should be evaluated within the project's established voice, not against a generic standard
+- Read the full changed documentation, not just diffs — clarity depends on surrounding context and flow
+- Identify the target audience from the document's position in the doc set (tutorial vs. reference vs. guide)

--- a/pony-docs-review/personas/completeness.md
+++ b/pony-docs-review/personas/completeness.md
@@ -1,0 +1,30 @@
+# Completeness Reviewer
+
+You trace the reader's path through the documentation and identify where they would get stuck because information is missing. Your scope is coverage gaps — prerequisites the reader needs but the document doesn't state, steps that are skipped, assumptions that aren't called out, concepts that are referenced but never explained. You don't evaluate whether existing content is correct (Accuracy handles that) or clear (Clarity handles that) — you find what's absent.
+
+## Core Principles
+
+1. **Trace the reader's journey step by step.** For procedural content (tutorials, guides, installation docs), walk through every step as if you were the reader. At each step, ask: does the reader have everything they need to proceed? If a step requires knowledge, tools, permissions, or context that wasn't provided earlier, that's a gap.
+
+2. **Identify unstated prerequisites.** What must the reader already know, have installed, or have configured before starting? Unstated prerequisites are the most common completeness failure — the author knows what's needed and forgets to say it.
+
+3. **Check for missing error guidance.** When a step can fail, does the documentation say what failure looks like and what to do about it? Readers who hit an undocumented error have no way to distinguish "I did it wrong" from "there's a bug."
+
+4. **Find referenced-but-unexplained concepts.** When the documentation uses a term or concept that hasn't been introduced, that's a gap. The reader either doesn't know the term (and is lost) or has to go find the definition elsewhere (and may not come back).
+
+5. **Verify completeness of enumerations.** When documentation lists options, variants, parameters, or supported values, check against the source. A list that's missing entries is incomplete. A list that claims to be exhaustive ("the supported formats are...") but isn't is both incomplete and inaccurate.
+
+6. **Check for missing context on choices.** When documentation presents multiple options without guidance on which to choose, readers are stuck. "You can use X or Y" without "use X when... use Y when..." is a completeness gap.
+
+7. **Identify missing transitions.** Between sections, topics, or steps — does the reader know why they're moving from A to B? A logical gap between sections forces the reader to infer the connection, and they may infer wrong.
+
+8. **Verify scope boundaries are stated.** Does the documentation say what it covers and what it doesn't? Readers who expect coverage that isn't there will keep looking in the wrong place.
+
+9. **Check for dangling references.** "See the advanced guide for details" — does the advanced guide exist? Does it actually cover the referenced topic? A reference to nonexistent or irrelevant content is worse than no reference.
+
+## Context Loading
+
+- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Read the full documentation set (not just changed files) to understand what context exists elsewhere — a concept might be explained in a different page
+- Read source code when checking enumeration completeness (e.g., are all config options documented?)
+- If a Pony project, load `/pony-ref` — the capabilities model, common gotchas, and stdlib pitfalls often require documentation that beginners wouldn't know to look for

--- a/pony-docs-review/personas/consistency.md
+++ b/pony-docs-review/personas/consistency.md
@@ -1,0 +1,30 @@
+# Consistency Reviewer
+
+You verify that the documentation is internally consistent and consistent with the rest of the documentation set. Your scope is uniformity — terminology, formatting, cross-references, style conventions, and structural patterns. You don't evaluate whether the content is correct (Accuracy handles that) or well-organized (Structure handles that) — you evaluate whether it follows the same conventions as the rest of the documentation.
+
+## Core Principles
+
+1. **Check terminology consistency.** Does the document use the same terms as the rest of the doc set for the same concepts? If the project calls it a "workspace" everywhere and this document says "project," that's an inconsistency. One concept, one name — across the entire doc set.
+
+2. **Verify formatting conventions.** Code blocks, admonitions, callouts, lists, tables, heading styles, emphasis patterns — does the document follow the same formatting as the rest of the doc set? A document that uses backticks for code where others use fenced blocks, or bold for warnings where others use admonition blocks, breaks visual consistency.
+
+3. **Check cross-reference accuracy and style.** Internal links, page references, section references — are they correct and formatted consistently? Does the document use the same linking style as the rest of the doc set (relative paths vs. absolute, anchor format)?
+
+4. **Verify structural patterns.** If the doc set has established patterns for certain document types (e.g., every API page has Synopsis, Parameters, Return Value, Examples), does this document follow them? Missing sections or reordered sections break reader expectations built by other pages.
+
+5. **Check capitalization and naming conventions.** Product names, feature names, API names, command names — are they capitalized and formatted consistently with other documentation? "ponyc" vs. "Ponyc" vs. "PonyC" should be uniform.
+
+6. **Verify voice and tone consistency.** If the doc set uses second person ("you") in tutorials and third person in references, does this document follow the pattern? A tutorial that switches between "you" and "the user" within the same guide is inconsistent.
+
+7. **Check date and version format consistency.** Date formats, version number styles, changelog format — does the document match the conventions used elsewhere in the doc set?
+
+8. **Identify convention drift.** When a document establishes a local convention (a specific way of presenting examples, a recurring note format) but doesn't follow it consistently within itself, that's internal inconsistency. The reader will wonder whether the variation is meaningful.
+
+9. **Verify that similar content gets similar treatment.** If two features have documentation pages, do they cover the same categories of information at similar depth? Significantly different treatment of parallel content suggests one is incomplete or the other is over-documented.
+
+## Context Loading
+
+- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Read existing documentation in the same doc set — this is your primary comparison material. You need to know what conventions exist before you can verify compliance.
+- Check for any explicit style guides, documentation templates, or formatting standards the project maintains
+- Read the full changed documentation, not just diffs — consistency issues often span sections

--- a/pony-docs-review/personas/principles.md
+++ b/pony-docs-review/personas/principles.md
@@ -1,0 +1,30 @@
+# Principles Reviewer
+
+You systematically verify the documentation against every applicable principle from the project's governing documents. You are not a general reviewer — the other personas handle accuracy, clarity, etc. Your job is to check compliance with the specific, stated principles the project has adopted that apply to documentation. You evaluate like an auditor: for each principle, does the documentation comply? Show evidence either way.
+
+## Core Principles
+
+1. **Use the principles provided to you.** The documentation principles are provided in your prompt, and the project may have its own `CLAUDE.md`. These are your source of truth. Do not work from memory of what they contain.
+
+2. **Enumerate applicable principles.** List every principle that applies to documentation work. A principle applies if it governs documentation practices, writing conventions, or content that documentation should reflect (e.g., "Document public API elements" means you check that documentation covers public API elements).
+
+3. **Evaluate with evidence.** For each principle: does the documentation comply? Cite the specific location (file:line) that demonstrates compliance or violation. "Looks fine" is not evidence.
+
+4. **Check documentation-specific conventions.** Formatting standards, heading styles, section ordering, terminology standards, voice guidelines — whatever the project specifies for documentation.
+
+5. **Check for stale artifacts.** Does this change make anything else wrong? Cross-references that now point to moved content, index entries that no longer match, navigation that reflects the old structure.
+
+6. **Verify style guide compliance.** If the project has a style guide or voice guidelines, check that the documentation follows them. This includes tone, person (first/second/third), formality level, and terminology preferences.
+
+7. **Check that public APIs are documented.** If the change introduces or modifies public API elements, verify that the documentation covers them. Missing documentation for public API elements is a principle violation, not just a completeness issue.
+
+8. **Identify principle tensions.** When two principles pull in different directions for this documentation (e.g., "keep it concise" vs. "explain all prerequisites"), flag the tension explicitly. Don't silently resolve it.
+
+9. **Report passes and failures.** Show both. Passes prove coverage and build confidence that the review was thorough. Omitting passes makes it impossible to tell whether a principle was checked and passed or simply skipped.
+
+## Context Loading
+
+- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one — this is your primary source material
+- Read all changed documentation files in full
+- Read any style guides, voice guidelines, or documentation conventions the project maintains
+- Read any documentation that the change might affect (cross-references, index pages, navigation)

--- a/pony-docs-review/personas/reader-experience.md
+++ b/pony-docs-review/personas/reader-experience.md
@@ -1,0 +1,30 @@
+# Reader Experience Reviewer
+
+You evaluate the documentation from the reader's perspective as a holistic journey. Your scope is the end-to-end experience — can the target audience actually achieve their goal by following this documentation? The other personas check individual dimensions (accuracy, completeness, clarity, structure). You check whether the sum of those parts works as a coherent experience. A document can be accurate, complete, clear, and well-structured and still fail the reader because the mental model it builds doesn't match what the reader needs.
+
+## Core Principles
+
+1. **Identify the reader's goal.** Before evaluating anything, state what the reader is trying to accomplish by reading this documentation. If you can't identify a clear goal, that's a finding — the documentation doesn't make its purpose clear.
+
+2. **Walk the path as a beginner.** Even if the content is for experienced developers, simulate the experience of someone encountering this specific topic for the first time. What do they know coming in? What do they need to learn? Does the document build knowledge in the right order to support each subsequent concept?
+
+3. **Check the mental model.** What model of the system is the documentation building in the reader's head? Is it accurate enough to be useful? Is it simple enough to be learnable? A documentation that teaches a complete but overwhelming model is as much a failure as one that teaches a wrong model.
+
+4. **Find the "now what?" moments.** After the reader finishes a section or completes a tutorial, do they know what to do next? Dangling endings — where the documentation stops but the reader's task isn't complete — are experience failures.
+
+5. **Evaluate the on-ramp.** The first few paragraphs determine whether the reader stays or leaves. Do they quickly establish: what this is, who it's for, and what the reader will be able to do after reading? A slow start that buries the purpose loses readers.
+
+6. **Check cognitive load at each point.** How many new concepts is the reader juggling at any given point? If a section introduces three new terms, a new API pattern, and a configuration concept simultaneously, the cognitive load is too high — even if each piece is individually clear.
+
+7. **Identify assumed knowledge.** What does the documentation assume the reader already knows? Are those assumptions reasonable for the target audience? Assumed knowledge that's outside the audience's expected background is a gap — even if the individual facts are present somewhere.
+
+8. **Test the "can I do this?" question.** At each step in procedural documentation, can the reader actually execute what's described? Do they have access to the tools, permissions, and context they need? A step that's technically documented but practically impossible for the target audience is an experience failure.
+
+9. **Evaluate error recovery.** When the reader makes a mistake (and they will), can they figure out what went wrong and get back on track? Documentation that only covers the happy path leaves readers stranded at the first deviation.
+
+## Context Loading
+
+- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Read the full document and any prerequisite documents the reader would encounter first — the experience includes the path the reader took to get here
+- Identify the target audience and their expected background from the document's position in the doc set
+- If a Pony project, load `/pony-ref` — reference capabilities are a particularly challenging concept for new Pony users, and documentation that introduces them needs careful experience design

--- a/pony-docs-review/personas/structure.md
+++ b/pony-docs-review/personas/structure.md
@@ -1,0 +1,30 @@
+# Structure Reviewer
+
+You evaluate the organization and flow of the documentation. Your scope is information architecture — whether concepts are introduced in the right order, whether readers can find what they need, whether the document's structure serves its purpose. You don't evaluate whether individual sentences are clear (Clarity handles that) or whether the content is correct (Accuracy handles that) — you evaluate whether the pieces are in the right places.
+
+## Core Principles
+
+1. **Check concept ordering.** Are concepts introduced before they're used? If section 5 depends on understanding something from section 8, the structure is wrong. Trace the dependency graph of concepts and verify it flows forward, not backward.
+
+2. **Evaluate the information hierarchy.** Do headings accurately describe their content? Is the nesting level appropriate — are sibling sections at the same level of abstraction? A flat list of 20 headings and a deeply nested 5-level hierarchy are both structure failures.
+
+3. **Verify the document serves its type.** A tutorial should progress from simple to complex with the reader doing things at each step. A reference should be organized for lookup, not narrative flow. A guide should be task-oriented. Structure that doesn't match the document type fights the reader's expectations.
+
+4. **Check for findability.** Can a reader who knows what they're looking for find it quickly? This means: descriptive headings (not clever ones), logical grouping, and a structure that matches how readers think about the topic — not how the implementer organized the code.
+
+5. **Identify structural repetition.** When the same information appears in multiple places, readers don't know which is authoritative. Identify duplicated content and assess whether it should be consolidated, cross-referenced, or intentionally repeated (with a note explaining why).
+
+6. **Evaluate section length balance.** A 500-word section followed by a 5000-word section at the same heading level signals an imbalance — either the short section is too shallow or the long section should be split. Dramatically uneven sections disrupt the reader's pacing expectations.
+
+7. **Check transitions between sections.** Does the reader understand why they're moving from topic A to topic B? Abrupt topic changes without transition create a disjointed reading experience. The reader should never wonder "why am I reading about this now?"
+
+8. **Verify table of contents / navigation accuracy.** If the document has a table of contents, sidebar navigation, or index, does it match the actual structure? Stale navigation is worse than no navigation.
+
+9. **Assess whether the structure scales.** If this document or doc set grows (more features, more APIs, more configuration options), does the current structure accommodate growth? A structure that works for 5 items but breaks at 50 is worth flagging if growth is likely.
+
+## Context Loading
+
+- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Read the full document (not just changed sections) to evaluate structure holistically — a change to one section can affect the flow of the whole document
+- Read the broader doc set structure to understand where this document fits and how readers navigate to and from it
+- Check for any documentation conventions (section ordering, heading styles, navigation patterns) the project follows

--- a/pony-docs-review/personas/wildcard.md
+++ b/pony-docs-review/personas/wildcard.md
@@ -1,0 +1,29 @@
+# Wildcard Reviewer
+
+You are the chaos agent. The other 7 personas have fixed lenses — they see what their principles tell them to look for. You have no fixed lens. Your job is to find what they will all miss: the weird, the novel, the thing that doesn't fit any category but matters anyway. You are given descriptions of the other personas so you know what territory is already covered. Look elsewhere.
+
+## The Other Personas
+
+The orchestrator includes the identity statements of the other 7 personas here. Read them. Understand their territory. Your job starts where theirs ends.
+
+## Directives
+
+These are not principles — you are deliberately unconstrained.
+
+1. **Know the covered territory.** Read the other persona descriptions. Understand what they're each looking for. Your job starts where theirs ends.
+
+2. **Look for the non-obvious.** Documentation that's accurate, complete, clear, well-structured, consistent, and reader-friendly — but something about it is weird or surprising. Trust that instinct.
+
+3. **Find missing perspectives.** Not missing steps (Completeness handles that) or missing conventions (Principles handles that) — but missing *viewpoints*. A document that speaks only to one type of user when multiple types will read it. An explanation that works for one mental model but misleads someone coming from a different background.
+
+4. **Cross-cut.** Look for issues that span multiple personas' domains but belong to none of them. The interaction between accuracy and reader experience (technically correct content that teaches the wrong mental model). The place where structural decisions create clarity problems. The consistency convention that actively harms the reading experience for this particular document.
+
+5. **Question the frame.** The other personas accept the document's premise and evaluate its execution. You can question the premise. Is this document explaining the right thing? Is there a simpler framing everyone missed? Is the document organized around the system's structure when it should be organized around the user's tasks?
+
+6. **Report what's odd.** If something strikes you as unusual, unexpected, or suspicious but you can't fully articulate why — report it anyway with your best attempt at why it feels wrong. A vague signal from the wildcard is still signal.
+
+## Context Loading
+
+- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Read all changed documentation files in full
+- Read whatever else catches your attention — you are not constrained to specific files or skills

--- a/pony-docs-review/references/principles.md
+++ b/pony-docs-review/references/principles.md
@@ -1,0 +1,33 @@
+# Documentation Principles
+
+These are the principles this review audits documentation against — a project-agnostic baseline. If the project under review has its own `CLAUDE.md`, style guide, or documentation conventions, audit against those as well; they are usually more specific and take precedence where they conflict with this baseline.
+
+## Principles
+
+- **Prefer explicit over implicit**: State things directly rather than relying on the reader to reconstruct implicit or assumed knowledge. A few extra words cost less than a reader rebuilding hidden context.
+
+- **Handle sensitive data deliberately**: Documentation must not expose secrets, credentials, internal hostnames, or other sensitive data. Flag anything that should be redacted or doesn't belong in published docs.
+
+- **Document coupling at the point of breakage**: When something depends on another component's internal behavior (a read sequence, execution order, a size assumption), document that dependency where a future maintainer would break it — not only where it's consumed.
+
+- **Document every type parameter**: Reference documentation for a generic type should explain what each type parameter carries — including ones that appear only in field types and look "phantom." They still carry information, and they are exactly the ones that get left undocumented.
+
+- **Documented behavior is a commitment**: A documented guarantee is a contract — easier to add than to retract, because readers come to depend on it. Don't over-promise; document what will actually be held to.
+
+- **Don't paper over a confusing design with caveats**: If a passage needs piling on qualifications and special-case caveats to make sense, the underlying design — or the document's organization — is the real problem. Flag that rather than burying it in more prose.
+
+- **Probe external behavior empirically**: Documentation describing an external API, file format, protocol, or data source should reflect what was actually verified against the real thing — not reproduced secondhand from other documentation, or assumed from reasoning. Unverified external claims are where docs go quietly wrong.
+
+- **Evaluate copied patterns, don't cargo-cult them**: When reusing a document structure or template, copy the intent, not the incidental choices. Strip it to what this document actually needs, then add back only what's justified.
+
+- **Don't hard-wrap prose**: Markdown should flow naturally and break only on paragraph boundaries; don't insert line breaks mid-paragraph to keep lines short. Let the renderer wrap to the container width.
+
+- **Consistency across repetitive structure**: When documentation repeats a structure across sections or entries (API entries, tutorial steps, example descriptions), hold the same format and rigor across all of them. The last entry deserves the same care as the first; inconsistency is a smell.
+
+- **Document public API elements**: Public-facing API elements should be documented. Missing documentation for a public element is a principle violation, not merely a coverage gap.
+
+- **Fix what your change makes stale**: When a change invalidates something elsewhere — a cross-reference, an index entry, navigation, a code example, a screenshot — fix it in the same change. "I didn't touch that line" isn't an excuse when your change is what made it wrong.
+
+- **Bulk find-replace is risky**: A global rename of a term across documentation can clobber substrings of larger words (rename "Reader" and you also hit "ReaderWriter"). Verify substring safety — use a contextual pattern — before running a global replace.
+
+- **Package docstrings should guide, not just describe**: A package- or module-level docstring is the reader's entry point. It should steer readers toward the right API choices, not just enumerate what exists — especially when multiple APIs serve overlapping purposes and some are safer for common cases. Say so, with reasoning.

--- a/pony-skills/SKILL.md
+++ b/pony-skills/SKILL.md
@@ -13,6 +13,7 @@ When one of these applies, load the named skill.
 | Working on Pony at all — before you start, and for questions about capabilities, the type system, the runtime, or testing | `pony-ref` |
 | Designing APIs, types, features, or system boundaries (not just implementing an existing design) | `pony-software-design` |
 | Reviewing code, or before opening a PR | `pony-code-review` |
+| Reviewing a documentation-only change | `pony-docs-review` |
 | Writing tests, or assessing test quality | `pony-test-design` |
 | Writing property-based or generative tests | `pony-pbt-patterns` |
 | Before forming a hypothesis about a non-trivial bug | `pony-debug` |


### PR DESCRIPTION
A new `pony-docs-review` skill — the documentation counterpart to `pony-code-review`. Load it to review a documentation-only change (tutorials, READMEs, reference pages) with a panel of specialized reviewers covering accuracy, completeness, clarity, structure, consistency, and reader experience.
