### PR TITLE
OpenAI Codex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ Skills for working with [Pony](https://www.ponylang.io) in any LLM coding harnes
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
 
+## Compatible with
+
+- [OpenAI Codex](https://developers.openai.com/codex) — Codex loads the same `SKILL.md` format from `~/.agents/skills`, where `install.py` installs them.
+
 **About the `pony-` prefix:** All skills in this repo use a `pony-` prefix as an org namespace to avoid name collisions with skills from other sources. Some skills (like `pony-ref`) are Pony-language-specific. Others (like `pony-ensemble` and `pony-code-review`) are language-agnostic methodology skills that work on any codebase — the prefix is about where they come from, not what languages they apply to.
 
 ## Installation
 
-Clone the repo and run the install script. It symlinks each skill into your harness's skills directory so they stay up to date when you pull.
+Clone the repo and run the install script. It detects which harnesses you have installed and symlinks each skill into their skills directory, so the skills stay up to date when you pull.
 
 ```bash
 git clone https://github.com/ponylang/llm-skills.git
@@ -18,7 +22,11 @@ cd llm-skills
 python install.py
 ```
 
+With no arguments, `install.py` installs for every harness it detects: Claude Code (into `~/.claude/skills/`) and Codex (into `~/.agents/skills/`). To target a specific harness regardless of what's detected, pass `--claude` and/or `--codex`.
+
 That's it. Start a new session and the skills are available.
+
+**Invoking a skill:** In Claude Code, load a skill with a slash command like `/pony-ref`. In Codex, skills load automatically based on their description, or you can mention one explicitly with `$pony-ref`.
 
 To update later:
 
@@ -35,7 +43,7 @@ No re-install needed — the symlinks point to your clone, so pulling new conten
 python install.py --uninstall
 ```
 
-This only removes the symlinks, not the cloned repo.
+This removes the symlinks from the detected harnesses (or from the harness you select with `--claude`/`--codex`), not the cloned repo.
 
 ## Skills
 
@@ -43,13 +51,13 @@ This only removes the symlinks, not the cloned repo.
 
 #### pony-skills
 
-A routing index for the other skills — load it with `/pony-skills` (or reference it from a Pony project's `CLAUDE.md`) and it tells you which `pony-*` skill to load for each task. The single-trigger alternative to wiring up each skill's trigger by hand; a good place to start.
+A routing index for the other skills — load it (or reference it from a Pony project's `CLAUDE.md` or `AGENTS.md`) and it tells you which `pony-*` skill to load for each task. The single-trigger alternative to wiring up each skill's trigger by hand; a good place to start.
 
 ### Pony Language
 
 #### pony-ref
 
-The Pony language reference. Load it with `/pony-ref` at the start of a Pony coding session or when you hit a question about capabilities, the type system, the runtime, or testing.
+The Pony language reference. Load it at the start of a Pony coding session or when you hit a question about capabilities, the type system, the runtime, or testing.
 
 What's in the quick reference (loaded into context automatically):
 
@@ -72,7 +80,7 @@ What's in the `references/` directory (read on demand for deeper questions):
 
 #### pony-examples-readme
 
-Conventions for writing `examples/README.md` files in ponylang projects. Load it with `/pony-examples-readme` when adding, updating, or reorganizing examples.
+Conventions for writing `examples/README.md` files in ponylang projects. Load it when adding, updating, or reorganizing examples.
 
 What's in the quick reference:
 
@@ -83,7 +91,7 @@ What's in the quick reference:
 
 #### pony-library-readme
 
-Conventions for writing Pony library project READMEs. Load it with `/pony-library-readme` when writing or updating a library's top-level README.
+Conventions for writing Pony library project READMEs. Load it when writing or updating a library's top-level README.
 
 What's in the quick reference:
 
@@ -93,7 +101,7 @@ What's in the quick reference:
 
 #### pony-release-notes
 
-How to write release notes and manage CHANGELOG entries in ponylang projects. Load it with `/pony-release-notes` when writing release notes, updating CHANGELOG, or preparing a PR with user-facing changes.
+How to write release notes and manage CHANGELOG entries in ponylang projects. Load it when writing release notes, updating CHANGELOG, or preparing a PR with user-facing changes.
 
 What's in the quick reference:
 
@@ -112,35 +120,35 @@ This skill assumes the target repo has the following GitHub Actions installed an
 
 #### pony-software-design
 
-Disciplines for software design work — APIs, type systems, features, system boundaries. Load it with `/pony-software-design` when designing new interfaces or deciding where ownership boundaries fall. Counters the tendency to retrieve familiar patterns instead of discovering what the problem needs.
+Disciplines for software design work — APIs, type systems, features, system boundaries. Load it when designing new interfaces or deciding where ownership boundaries fall. Counters the tendency to retrieve familiar patterns instead of discovering what the problem needs.
 
 Has full (8-persona) and lightweight (5-persona) modes. Full mode runs design (3 personas) and evaluation (5 personas) stages with a feedback loop. Lightweight mode keeps all design personas but reduces evaluation to 2 personas in a single pass.
 
 #### pony-code-review
 
-Ensemble code review with specialized reviewer personas. Load it with `/pony-code-review` when conducting a code review of a PR, branch, or local changes.
+Ensemble code review with specialized reviewer personas. Load it when conducting a code review of a PR, branch, or local changes.
 
 Has full (8-persona, iterative re-review) and lightweight (3-persona, single pass) modes. Personas cover correctness, security, performance, API design, test quality, adversarial scenarios, design principles, and wildcard concerns.
 
 #### pony-docs-review
 
-Ensemble documentation review — the prose counterpart to `pony-code-review`. Load it with `/pony-docs-review` when reviewing a documentation-only change (tutorials, READMEs, reference pages). Has full (8-persona, iterative re-review) and lightweight (3-persona, single pass) modes; personas cover accuracy, completeness, clarity, structure, consistency, reader experience, principles, and wildcard concerns.
+Ensemble documentation review — the prose counterpart to `pony-code-review`. Load it when reviewing a documentation-only change (tutorials, READMEs, reference pages). Has full (8-persona, iterative re-review) and lightweight (3-persona, single pass) modes; personas cover accuracy, completeness, clarity, structure, consistency, reader experience, principles, and wildcard concerns.
 
 #### pony-test-design
 
-Two-stage ensemble for planning meaningful tests. Load it with `/pony-test-design` when writing tests for new features or reviewing test quality. Counters the tendency to write tests that exercise the stdlib instead of your code.
+Two-stage ensemble for planning meaningful tests. Load it when writing tests for new features or reviewing test quality. Counters the tendency to write tests that exercise the stdlib instead of your code.
 
 Has full (8-persona) and lightweight (5-persona) modes. Stage 1 (planning) produces a test strategy from three different analytical angles. Stage 2 (evaluation) stress-tests the strategy for coverage gaps, weak assertions, and missed property-testing opportunities.
 
 #### pony-pbt-patterns
 
-Property-based and generative testing patterns. Load it with `/pony-pbt-patterns` when writing property-based tests, generators, or generative test suites.
+Property-based and generative testing patterns. Load it when writing property-based tests, generators, or generative test suites.
 
 Built on one idea — chance is not coverage, so a generator must bias toward where bugs live. Covers biasing toward important values, swarm testing (varying which operations are enabled so emergent state reaches the extremes), the valid/invalid/mixed boundary triad, compositional generators, and multi-angle oracles. Maps directly onto PonyCheck.
 
 #### pony-debug
 
-Structured debugging protocol with checkpoints. Load it with `/pony-debug` when debugging non-trivial issues — before forming any hypothesis about the cause.
+Structured debugging protocol with checkpoints. Load it when debugging non-trivial issues — before forming any hypothesis about the cause.
 
 Provides an OODA-loop investigation process: characterize the failure, gather context, build a minimal reproduction, then iterate through hypothesis/experiment/observe cycles until all symptoms are explained. Especially valuable for Pony's subtle failure modes (capability violations, FFI issues, actor lifecycle problems, CI timeouts from undisposed resources).
 
@@ -148,13 +156,13 @@ Provides an OODA-loop investigation process: characterize the failure, gather co
 
 #### pony-ensemble
 
-The mechanical process for producing higher-confidence outputs through decorrelated reasoning paths. Load it with `/pony-ensemble` when you want the ensemble approach. Multiple agents work the same problem with slightly different attention focuses, then a synthesizer integrates their outputs.
+The mechanical process for producing higher-confidence outputs through decorrelated reasoning paths. Load it when you want the ensemble approach. Multiple agents work the same problem with slightly different attention focuses, then a synthesizer integrates their outputs.
 
 This is infrastructure — `pony-software-design`, `pony-code-review`, and `pony-test-design` all build on it with domain-specific customizations.
 
 #### pony-synthesize
 
-Fixed instructions for the ensemble synthesizer — integrates multiple agent outputs into a single higher-quality result. Load it with `/pony-synthesize` as part of the ensemble workflow.
+Fixed instructions for the ensemble synthesizer — integrates multiple agent outputs into a single higher-quality result. Load it as part of the ensemble workflow.
 
 This is infrastructure — loaded by `pony-ensemble` during the synthesis step.
 
@@ -162,48 +170,48 @@ This is infrastructure — loaded by `pony-ensemble` during the synthesis step.
 
 Add these to your `CLAUDE.md` or `AGENTS.md` to load skills automatically when relevant. Two ways to do it: load the `pony-skills` routing index with a single trigger that covers all of them, or add individual triggers for just the skills you want.
 
-### /pony-skills
+### pony-skills trigger
 
-> **Load `/pony-skills` at the start of Pony work**: At the start of work in a Pony project, load the `pony-skills` skill — a routing index that tells you which `pony-*` skill to load for each task. This one trigger covers all of the skills below.
+> **Load `pony-skills` at the start of Pony work**: At the start of work in a Pony project, load the `pony-skills` skill — a routing index that tells you which `pony-*` skill to load for each task. This one trigger covers all of the skills below.
 
 Prefer to pick individually? Add any of these instead:
 
-### /pony-ref
+### pony-ref trigger
 
-> **Load `/pony-ref` proactively when working on Pony code**: At the start of any conversation where the working directory is a Pony project (contains `corral.json` or `*.pony` files), load `/pony-ref` before doing any work. Also load it mid-conversation when hitting capabilities, type system, runtime, or testing questions.
+> **Load `pony-ref` proactively when working on Pony code**: At the start of any conversation where the working directory is a Pony project (contains `corral.json` or `*.pony` files), load `pony-ref` before doing any work. Also load it mid-conversation when hitting capabilities, type system, runtime, or testing questions.
 
-### /pony-examples-readme
+### pony-examples-readme trigger
 
-> **Load `/pony-examples-readme` when working on examples**: Load it when adding, updating, or reorganizing examples in a Pony project, or when writing an `examples/README.md`.
+> **Load `pony-examples-readme` when working on examples**: Load it when adding, updating, or reorganizing examples in a Pony project, or when writing an `examples/README.md`.
 
-### /pony-library-readme
+### pony-library-readme trigger
 
-> **Load `/pony-library-readme` for library READMEs**: Load it when writing or updating a `README.md` for a Pony library project.
+> **Load `pony-library-readme` for library READMEs**: Load it when writing or updating a `README.md` for a Pony library project.
 
-### /pony-release-notes
+### pony-release-notes trigger
 
-> **Load `/pony-release-notes` for release notes and CHANGELOG**: Load it when writing release notes, updating CHANGELOG, or preparing a PR that includes user-facing changes in a Pony project.
+> **Load `pony-release-notes` for release notes and CHANGELOG**: Load it when writing release notes, updating CHANGELOG, or preparing a PR that includes user-facing changes in a Pony project.
 
-### /pony-software-design
+### pony-software-design trigger
 
-> **Load `/pony-software-design` for design work**: When the task involves designing APIs, type systems, features, or system boundaries — not just implementing an existing design — load `/pony-software-design` before starting. This includes any work where you're deciding what types to create, what a public interface looks like, or where ownership boundaries fall.
+> **Load `pony-software-design` for design work**: When the task involves designing APIs, type systems, features, or system boundaries — not just implementing an existing design — load `pony-software-design` before starting. This includes any work where you're deciding what types to create, what a public interface looks like, or where ownership boundaries fall.
 
-### /pony-code-review
+### pony-code-review trigger
 
-> **Load `/pony-code-review` for code reviews**: When conducting a code review of a PR, branch, or local changes, load `/pony-code-review`. Not for one-line config changes or typo fixes.
+> **Load `pony-code-review` for code reviews**: When conducting a code review of a PR, branch, or local changes, load `pony-code-review`. Not for one-line config changes or typo fixes.
 
-### /pony-docs-review
+### pony-docs-review trigger
 
-> **Load `/pony-docs-review` for documentation reviews**: When reviewing a documentation-only change (tutorials, READMEs, reference pages), load `/pony-docs-review`. Not for one-line typo or formatting fixes.
+> **Load `pony-docs-review` for documentation reviews**: When reviewing a documentation-only change (tutorials, READMEs, reference pages), load `pony-docs-review`. Not for one-line typo or formatting fixes.
 
-### /pony-test-design
+### pony-test-design trigger
 
-> **Load `/pony-test-design` when writing tests**: Before writing tests for new features or reviewing test quality, load `/pony-test-design`.
+> **Load `pony-test-design` when writing tests**: Before writing tests for new features or reviewing test quality, load `pony-test-design`.
 
-### /pony-pbt-patterns
+### pony-pbt-patterns trigger
 
-> **Load `/pony-pbt-patterns` when writing property-based tests**: Load it when writing property-based tests, generators, or generative test suites, especially with PonyCheck.
+> **Load `pony-pbt-patterns` when writing property-based tests**: Load it when writing property-based tests, generators, or generative test suites, especially with PonyCheck.
 
-### /pony-debug
+### pony-debug trigger
 
-> **Load `/pony-debug` when you start debugging**: Before forming any hypothesis about the cause of a non-trivial issue, load `/pony-debug`. It provides a structured protocol with checkpoints.
+> **Load `pony-debug` when you start debugging**: Before forming any hypothesis about the cause of a non-trivial issue, load `pony-debug`. It provides a structured protocol with checkpoints.

--- a/install.py
+++ b/install.py
@@ -1,14 +1,25 @@
 #!/usr/bin/env python3
-"""Install Pony LLM skills by symlinking skill directories into Claude Code.
+"""Install Pony LLM skills by symlinking skill directories into your AI harness.
 
 Usage:
-    python install.py              Install (create symlinks)
+    python install.py              Install for all detected harnesses
+    python install.py --claude     Install for Claude Code
+    python install.py --codex      Install for Codex
+    python install.py --claude --codex   Install for both
     python install.py --uninstall  Remove all symlinks pointing into this repo
     python install.py --dry-run    Show what would be done without doing it
 
 What it does:
-- Symlinks each top-level skill directory (containing SKILL.md) into
-  ~/.claude/skills/
+- Symlinks each top-level skill directory (containing SKILL.md) into the
+  user-level skills directory of each selected harness:
+    Claude Code: ~/.claude/skills/
+    Codex:       ~/.agents/skills/
+
+Harness selection:
+- With no --claude/--codex flag, installs for every harness detected on this
+  machine: Claude Code if ~/.claude exists; Codex if ~/.codex or ~/.agents
+  exists. Pass --claude and/or --codex to force specific targets regardless of
+  what is detected (the skills directory is created as needed).
 
 Existing symlinks pointing into this repo are updated silently.
 Existing files/directories that are NOT symlinks are never overwritten —
@@ -22,15 +33,60 @@ administrator.
 import sys
 from pathlib import Path
 
+# Each harness maps to the marker directories that signal it is installed and
+# the user-level skills directory (relative to home) we symlink into. Codex
+# follows the cross-harness ~/.agents/skills location; ~/.codex is config-only,
+# so either ~/.codex or ~/.agents counts as "Codex is present".
+HARNESSES = {
+    "claude": {
+        "label": "Claude Code",
+        "markers": (".claude",),
+        "skills": (".claude", "skills"),
+    },
+    "codex": {
+        "label": "Codex",
+        "markers": (".codex", ".agents"),
+        "skills": (".agents", "skills"),
+    },
+}
+
 
 def repo_dir():
     """Return the absolute path to the repository root."""
     return Path(__file__).resolve().parent
 
 
-def claude_home():
-    """Return the path to ~/.claude."""
-    return Path.home() / ".claude"
+def skills_dir(home, name):
+    """Return the skills directory for a harness under the given home."""
+    return home.joinpath(*HARNESSES[name]["skills"])
+
+
+def detected(home, name):
+    """Return True if the harness appears installed (a marker dir exists)."""
+    return any((home / marker).is_dir() for marker in HARNESSES[name]["markers"])
+
+
+def selected_harnesses(args, home):
+    """Resolve which harnesses to act on: forced by flags, else detected."""
+    forced = [name for name in HARNESSES if f"--{name}" in args]
+    if forced:
+        return forced
+    return [name for name in HARNESSES if detected(home, name)]
+
+
+def blocking_ancestor(path):
+    """Return the nearest existing ancestor of path that is not a directory.
+
+    Detects when a skills directory cannot be created because a parent
+    component is a file or a broken symlink. Returns None when the path is
+    creatable (its nearest existing ancestor is a directory).
+    """
+    for candidate in (path, *path.parents):
+        if candidate.is_symlink() and not candidate.exists():
+            return candidate
+        if candidate.exists():
+            return None if candidate.is_dir() else candidate
+    return None
 
 
 def symlink(src, dst, dry_run):
@@ -53,8 +109,27 @@ def symlink(src, dst, dry_run):
     return f"  link: {dst} -> {src}"
 
 
+def install_into(repo, skills_dst, dry_run):
+    """Symlink each skill directory (top-level dirs with SKILL.md) into skills_dst."""
+    blocker = blocking_ancestor(skills_dst)
+    if blocker is not None:
+        print(f"  SKIP (not a directory): {blocker}")
+        return
+    found_any = False
+    for skill_dir in sorted(repo.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        if not (skill_dir / "SKILL.md").exists():
+            continue
+        found_any = True
+        print(symlink(skill_dir, skills_dst / skill_dir.name, dry_run))
+    if not found_any:
+        print("  (no skill directories found)")
+    remove_stale_symlinks(repo, skills_dst, dry_run)
+
+
 def remove_stale_symlinks(repo, skills_dst, dry_run):
-    """Remove symlinks in skills_dst that point into repo but whose targets no longer exist."""
+    """Remove symlinks in skills_dst that point into repo but whose targets are gone."""
     if not skills_dst.is_dir():
         return
     stale = []
@@ -69,17 +144,17 @@ def remove_stale_symlinks(repo, skills_dst, dry_run):
         if not target.exists():
             stale.append(entry)
     if stale:
-        print("\nStale skill symlinks:")
+        print("  Stale skill symlinks:")
         for entry in stale:
             if not dry_run:
                 entry.unlink()
-            print(f"  remove: {entry}")
+            print(f"    remove: {entry}")
 
 
 def uninstall(repo, skills_dst, dry_run):
     """Remove all symlinks in skills_dst that point into repo."""
     if not skills_dst.is_dir():
-        print("Nothing to uninstall (skills directory does not exist).")
+        print("  Nothing to uninstall (skills directory does not exist).")
         return
     removed = []
     for entry in sorted(skills_dst.iterdir()):
@@ -92,53 +167,62 @@ def uninstall(repo, skills_dst, dry_run):
             continue
         removed.append(entry)
     if not removed:
-        print("No symlinks pointing into this repo found.")
+        print("  No symlinks pointing into this repo found.")
         return
-    print("Removing:")
+    print("  Removing:")
     for entry in removed:
         if not dry_run:
             entry.unlink()
-        print(f"  {entry}")
+        print(f"    {entry}")
 
 
 def main():
-    """Install skills by symlinking into ~/.claude/skills/."""
-    if len(sys.argv) > 1 and sys.argv[1] in ("-h", "--help"):
+    """Install or uninstall skills for the selected/detected harnesses."""
+    args = sys.argv[1:]
+    if "-h" in args or "--help" in args:
         print(__doc__.strip())
         sys.exit(0)
 
-    dry_run = "--dry-run" in sys.argv
+    known = {"--dry-run", "--uninstall", "--claude", "--codex"}
+    unknown = [arg for arg in args if arg not in known]
+    if unknown:
+        print(f"Unknown option(s): {' '.join(unknown)}")
+        print("Run with --help for usage.")
+        sys.exit(2)
+
+    dry_run = "--dry-run" in args
+    do_uninstall = "--uninstall" in args
 
     if dry_run:
         print("=== DRY RUN (no changes will be made) ===\n")
 
     repo = repo_dir()
-    home = claude_home()
+    home = Path.home()
+    targets = selected_harnesses(args, home)
 
-    if "--uninstall" in sys.argv:
-        uninstall(repo, home / "skills", dry_run)
-    else:
-        # Symlink each skill directory (top-level dirs containing SKILL.md)
-        print("Skills:")
-        found_any = False
-        for skill_dir in sorted(repo.iterdir()):
-            if not skill_dir.is_dir():
-                continue
-            if not (skill_dir / "SKILL.md").exists():
-                continue
-            found_any = True
-            dst = home / "skills" / skill_dir.name
-            print(symlink(skill_dir, dst, dry_run))
+    if not targets:
+        print("No supported harness detected (looked for ~/.claude, ~/.codex, "
+              "~/.agents).")
+        if do_uninstall:
+            print("Pass --claude and/or --codex to uninstall from a specific "
+                  "harness.")
+        else:
+            print("Pass --claude and/or --codex to install anyway.")
+        return
 
-        if not found_any:
-            print("  (no skill directories found)")
-
-        remove_stale_symlinks(repo, home / "skills", dry_run)
+    for name in targets:
+        dst = skills_dir(home, name)
+        print(f"{HARNESSES[name]['label']} ({dst}):")
+        if do_uninstall:
+            uninstall(repo, dst, dry_run)
+        else:
+            install_into(repo, dst, dry_run)
+        print()
 
     if dry_run:
-        print("\n=== DRY RUN complete (no changes were made) ===")
+        print("=== DRY RUN complete (no changes were made) ===")
     else:
-        print("\nDone.")
+        print("Done.")
 
 
 if __name__ == "__main__":

--- a/pony-code-review/SKILL.md
+++ b/pony-code-review/SKILL.md
@@ -41,13 +41,13 @@ These modes apply to both full and lightweight:
 
 ## Relationship to Ensemble Workflow
 
-Use the ensemble workflow with review-specific customizations. Load `/pony-ensemble` for the mechanical process. This skill replaces the generic attention focuses with review personas (8 for full mode, 3 for lightweight) and replaces the generic agent output format with the review-specific format defined below.
+Use the ensemble workflow with review-specific customizations. Load `pony-ensemble` for the mechanical process. This skill replaces the generic attention focuses with review personas (8 for full mode, 3 for lightweight) and replaces the generic agent output format with the review-specific format defined below.
 
 The Adversarial persona satisfies the ensemble's "fix reviews require an adversarial focus" requirement — when the review target is a fix, the Adversarial persona naturally focuses on showing the fix is incomplete per its identity statement.
 
 Persona agents write detailed evidence to files and return structured summaries to the orchestrator. The synthesizer works from summaries and digs into evidence files only when it needs to examine a finding more closely. This prevents context overload during synthesis.
 
-The pony-synthesize skill's output format (Integrated Result, Synthesis Rationale, etc.) is not a natural fit for code review. The orchestrator instructs the synthesizer to produce output in the review-specific final format (below) rather than the generic synthesizer format. No changes to `/pony-synthesize` itself.
+The pony-synthesize skill's output format (Integrated Result, Synthesis Rationale, etc.) is not a natural fit for code review. The orchestrator instructs the synthesizer to produce output in the review-specific final format (below) rather than the generic synthesizer format. No changes to `pony-synthesize` itself.
 
 ## Design Values
 
@@ -81,10 +81,10 @@ When principles conflict, these values set the priority. We value the left side 
 
 3. **Create a temporary directory for evidence files.** Use `~/tmp/code-review-<timestamp>/`. Each persona will write its detailed evidence to a file in this directory. Generate the file path for each persona (e.g., `correctness-evidence.md`) and pass it in the prompt.
 
-4. **Spawn 8 persona agents in parallel** as Tasks with subagent_type="general-purpose" and model="opus". Each agent's prompt includes:
+4. **Spawn 8 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. Each agent's prompt includes:
 
-   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `/pony-test-design`, `/pony-pbt-patterns`, `/pony-ref`), read that skill's content and include it in the agent prompt.
-   - The code-review principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project `CLAUDE.md` if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
+   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `pony-test-design`, `pony-pbt-patterns`, `pony-ref`), read that skill's content and include it in the agent prompt.
+   - The code-review principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project `AGENTS.md` if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
    - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
    - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
    - For Correctness, Adversarial, and Tests personas: the captured build output and test results from step 2.
@@ -96,7 +96,7 @@ When principles conflict, these values set the priority. We value the left side 
 
 5. **Triage agent outputs** per ensemble protocol — check that each persona addressed the actual code and stayed coherent.
 
-6. **Pass triaged persona summaries to a synthesis agent** loaded with `/pony-synthesize`, plus the review-specific synthesis focus (below). Provide the paths to each persona's evidence file so the synthesizer can dig in when needed. Instruct the synthesizer to produce its output in the final review format (below) rather than the generic synthesizer format. If this is a re-review (iterative mode), include the full review history: for each prior round, what was found, what was fixed, what was parked. The synthesizer uses this to verify fixes, avoid re-flagging parked items, and detect convergence failures.
+6. **Pass triaged persona summaries to a synthesis agent** loaded with `pony-synthesize`, plus the review-specific synthesis focus (below). Provide the paths to each persona's evidence file so the synthesizer can dig in when needed. Instruct the synthesizer to produce its output in the final review format (below) rather than the generic synthesizer format. If this is a re-review (iterative mode), include the full review history: for each prior round, what was found, what was fixed, what was parked. The synthesizer uses this to verify fixes, avoid re-flagging parked items, and detect convergence failures.
 
 7. **Reviewer loop on the synthesis** — the reviewer verifies that no persona findings were dropped, severity changes from individual findings are justified, and cross-persona patterns were correctly identified.
 
@@ -139,7 +139,7 @@ The loop ends when no findings remain except parked and out-of-scope items. At t
 
 ## Process: Lightweight Mode
 
-Lightweight mode runs 3 personas in a single pass with no iterative re-review. Load `/pony-ensemble` for the mechanical process.
+Lightweight mode runs 3 personas in a single pass with no iterative re-review. Load `pony-ensemble` for the mechanical process.
 
 ### Personas
 
@@ -174,10 +174,10 @@ Pick whichever is most relevant to the change. If multiple conditions apply, pic
 
 3. **Create a temporary directory for evidence files.** Use `~/tmp/code-review-<timestamp>/`. Same convention as full mode.
 
-4. **Spawn 3 persona agents in parallel** as Tasks with subagent_type="general-purpose" and model="opus". Each agent's prompt includes:
+4. **Spawn 3 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. Each agent's prompt includes:
 
-   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `/pony-test-design`, `/pony-pbt-patterns`, `/pony-ref`), read that skill's content and include it in the agent prompt.
-   - The code-review principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project `CLAUDE.md` if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
+   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `pony-test-design`, `pony-pbt-patterns`, `pony-ref`), read that skill's content and include it in the agent prompt.
+   - The code-review principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project `AGENTS.md` if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
    - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
    - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
    - The captured build output and test results from step 2 — always provided to Correctness and Adversarial. Also provided to Tests when it is the context-dependent persona.
@@ -191,7 +191,7 @@ Pick whichever is most relevant to the change. If multiple conditions apply, pic
 
 5. **Triage agent outputs** per ensemble protocol — check that each persona addressed the actual code and stayed coherent.
 
-6. **Pass triaged persona summaries to a synthesis agent** loaded with `/pony-synthesize`, plus the lightweight synthesis focus (below). Provide the paths to each persona's evidence file so the synthesizer can dig in when needed. Instruct the synthesizer to produce its output in the final review format (below) rather than the generic synthesizer format — same override as full mode.
+6. **Pass triaged persona summaries to a synthesis agent** loaded with `pony-synthesize`, plus the lightweight synthesis focus (below). Provide the paths to each persona's evidence file so the synthesizer can dig in when needed. Instruct the synthesizer to produce its output in the final review format (below) rather than the generic synthesizer format — same override as full mode.
 
 7. **Reviewer loop on the synthesis** — same checks as full mode: verify no persona findings were dropped, severity changes from individual findings are justified, and cross-persona patterns were correctly identified.
 

--- a/pony-code-review/personas/adversarial.md
+++ b/pony-code-review/personas/adversarial.md
@@ -24,6 +24,6 @@ You try to break the code. You work backward from failure scenarios, not forward
 
 ## Context Loading
 
-- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one
-- If a Pony project, load `/pony-ref` — capabilities, actor patterns, partial functions, and the mort pattern are especially relevant for constructing adversarial scenarios, but all sections provide context for finding failure modes
+- Review against the code-review principles provided in your prompt, and the project's `AGENTS.md` if it has one
+- If a Pony project, load `pony-ref` — capabilities, actor patterns, partial functions, and the mort pattern are especially relevant for constructing adversarial scenarios, but all sections provide context for finding failure modes
 - Read all changed files plus their callers and dependents — adversarial analysis requires understanding the broader system

--- a/pony-code-review/personas/api-design.md
+++ b/pony-code-review/personas/api-design.md
@@ -24,6 +24,6 @@ You evaluate the code from the consumer's perspective. How does it look to use, 
 
 ## Context Loading
 
-- Review against the code-review principles provided in your prompt (especially the code design principles), and the project's `CLAUDE.md` if it has one
+- Review against the code-review principles provided in your prompt (especially the code design principles), and the project's `AGENTS.md` if it has one
 - Read existing APIs in the project for pattern comparison
-- If a Pony project, load `/pony-ref` in full — the key patterns, common gotchas, composition patterns, and mort pattern sections are essential for evaluating whether code uses standard Pony patterns or reinvents degenerate versions. Also load `/pony-pbt-patterns` for test-related API patterns.
+- If a Pony project, load `pony-ref` in full — the key patterns, common gotchas, composition patterns, and mort pattern sections are essential for evaluating whether code uses standard Pony patterns or reinvents degenerate versions. Also load `pony-pbt-patterns` for test-related API patterns.

--- a/pony-code-review/personas/correctness.md
+++ b/pony-code-review/personas/correctness.md
@@ -24,6 +24,6 @@ You verify the code correctly implements its specification for valid inputs and 
 
 ## Context Loading
 
-- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one
-- If a Pony project, load `/pony-ref` — the correctness pitfalls, capabilities table, and stdlib pitfalls sections are especially relevant, but the rest provides necessary context for evaluating correctness in Pony
+- Review against the code-review principles provided in your prompt, and the project's `AGENTS.md` if it has one
+- If a Pony project, load `pony-ref` — the correctness pitfalls, capabilities table, and stdlib pitfalls sections are especially relevant, but the rest provides necessary context for evaluating correctness in Pony
 - Read the full source of all changed files, not just diffs — correctness depends on surrounding context

--- a/pony-code-review/personas/performance.md
+++ b/pony-code-review/personas/performance.md
@@ -24,6 +24,6 @@ You evaluate runtime efficiency and resource usage. You look at two levels: arch
 
 ## Context Loading
 
-- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one
-- If a Pony project, load `/pony-ref` — the performance cheat sheet is especially relevant to your focus, but the rest provides essential context: capabilities affect what optimizations are possible, actor patterns affect concurrency design, and common gotchas include performance-relevant pitfalls. Don't tunnel-vision on the cheat sheet alone.
+- Review against the code-review principles provided in your prompt, and the project's `AGENTS.md` if it has one
+- If a Pony project, load `pony-ref` — the performance cheat sheet is especially relevant to your focus, but the rest provides essential context: capabilities affect what optimizations are possible, actor patterns affect concurrency design, and common gotchas include performance-relevant pitfalls. Don't tunnel-vision on the cheat sheet alone.
 - Identify hot paths from the call graph before judging severity

--- a/pony-code-review/personas/principles.md
+++ b/pony-code-review/personas/principles.md
@@ -4,7 +4,7 @@ You systematically verify the code against every applicable principle from the p
 
 ## Core Principles
 
-1. **Use the principles provided to you.** The code-review principles are provided in your prompt, and the project may have its own `CLAUDE.md`. These are your source of truth. Do not work from memory of what they contain.
+1. **Use the principles provided to you.** The code-review principles are provided in your prompt, and the project may have its own `AGENTS.md`. These are your source of truth. Do not work from memory of what they contain.
 
 2. **Enumerate applicable principles.** List every principle that applies to this change. A principle applies if the change touches code in its domain (e.g., testing principles apply if tests were changed or should have been changed).
 
@@ -14,7 +14,7 @@ You systematically verify the code against every applicable principle from the p
 
 5. **Check code change discipline.** Pattern evaluation (not cargo-culting), line splitting, consistency across repetitive structure, documentation of public elements, staleness.
 
-6. **Verify conventions are followed.** Naming conventions, file organization, test structure, documentation patterns — whatever the project CLAUDE.md specifies.
+6. **Verify conventions are followed.** Naming conventions, file organization, test structure, documentation patterns — whatever the project AGENTS.md specifies.
 
 7. **Check for stale artifacts.** Does this change make anything else wrong? Comments, docstrings, test descriptions, documentation, configuration references that now describe the old behavior.
 
@@ -24,6 +24,6 @@ You systematically verify the code against every applicable principle from the p
 
 ## Context Loading
 
-- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one — this is your primary source material
+- Review against the code-review principles provided in your prompt, and the project's `AGENTS.md` if it has one — this is your primary source material
 - Read all changed files in full
 - Read any documentation files that the change might affect

--- a/pony-code-review/personas/security.md
+++ b/pony-code-review/personas/security.md
@@ -24,6 +24,6 @@ You look for vulnerabilities, unsafe patterns, and places where an attacker or u
 
 ## Context Loading
 
-- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Review against the code-review principles provided in your prompt, and the project's `AGENTS.md` if it has one
 - Identify the language and framework to focus on relevant vulnerability classes
 - Read all changed files plus any authentication/authorization code they interact with

--- a/pony-code-review/personas/tests.md
+++ b/pony-code-review/personas/tests.md
@@ -24,7 +24,7 @@ You evaluate whether the tests are meaningful and sufficient. A test suite that 
 
 ## Context Loading
 
-- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one
-- `/pony-test-design` skill content (included by orchestrator)
-- If property tests are present or appropriate, `/pony-pbt-patterns` (included by orchestrator)
+- Review against the code-review principles provided in your prompt, and the project's `AGENTS.md` if it has one
+- `pony-test-design` skill content (included by orchestrator)
+- If property tests are present or appropriate, `pony-pbt-patterns` (included by orchestrator)
 - Read the test files AND the code they test — you can't evaluate test quality without understanding what's being tested

--- a/pony-code-review/personas/wildcard.md
+++ b/pony-code-review/personas/wildcard.md
@@ -24,6 +24,6 @@ These are not principles — you are deliberately unconstrained.
 
 ## Context Loading
 
-- Review against the code-review principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Review against the code-review principles provided in your prompt, and the project's `AGENTS.md` if it has one
 - Read all changed files in full
 - Read whatever else catches your attention — you are not constrained to specific files or skills

--- a/pony-code-review/references/principles.md
+++ b/pony-code-review/references/principles.md
@@ -2,7 +2,7 @@
 
 These are the code-design principles and code-change discipline this review audits against. They are a project-agnostic baseline — the standard a change is expected to meet regardless of language or domain.
 
-If the project under review has its own `CLAUDE.md` or other stated conventions, audit against those as well. Project conventions are usually more specific (naming schemes, file organization, architectural boundaries) and take precedence where they conflict with this baseline.
+If the project under review has its own `AGENTS.md` or other stated conventions, audit against those as well. Project conventions are usually more specific (naming schemes, file organization, architectural boundaries) and take precedence where they conflict with this baseline.
 
 ## Code Design Principles
 

--- a/pony-docs-review/SKILL.md
+++ b/pony-docs-review/SKILL.md
@@ -40,13 +40,13 @@ These modes apply to both full and lightweight:
 
 ## Relationship to Ensemble Workflow
 
-Use the ensemble workflow with documentation-review-specific customizations. Load `/pony-ensemble` for the mechanical process. This skill replaces the generic attention focuses with documentation review personas (8 for full mode, 3 for lightweight) and replaces the generic agent output format with the review-specific format defined below.
+Use the ensemble workflow with documentation-review-specific customizations. Load `pony-ensemble` for the mechanical process. This skill replaces the generic attention focuses with documentation review personas (8 for full mode, 3 for lightweight) and replaces the generic agent output format with the review-specific format defined below.
 
 The ensemble protocol requires an adversarial focus when reviewing fixes. Pony-docs-review does not have a dedicated adversarial persona because documentation "fixes" (correcting factual errors, filling gaps) don't have the same failure mode as code fixes — there's no analog to "the bug still occurs despite the fix." When a pony-docs-review targets a documentation fix, the Accuracy persona naturally covers the adversarial concern: verifying that the corrected information is actually correct and that the fix doesn't introduce new inaccuracies. This satisfies the ensemble protocol's "fix reviews require an adversarial focus" requirement — no additional adversarial agent is needed. The orchestrator should note this in the Accuracy persona's prompt when the review target is a fix.
 
 Persona agents write detailed evidence to files and return structured summaries to the orchestrator. The synthesizer works from summaries and digs into evidence files only when it needs to examine a finding more closely. This prevents context overload during synthesis.
 
-The pony-synthesize skill's output format is not a natural fit for documentation review. The orchestrator instructs the synthesizer to produce output in the review-specific final format (below) rather than the generic synthesizer format. No changes to `/pony-synthesize` itself.
+The pony-synthesize skill's output format is not a natural fit for documentation review. The orchestrator instructs the synthesizer to produce output in the review-specific final format (below) rather than the generic synthesizer format. No changes to `pony-synthesize` itself.
 
 ## Process: Full Mode
 
@@ -61,10 +61,10 @@ The pony-synthesize skill's output format is not a natural fit for documentation
 
 3. **Create a temporary directory for evidence files.** Use `~/tmp/pony-docs-review-<timestamp>/`. Each persona will write its detailed evidence to a file in this directory. Generate the file path for each persona (e.g., `accuracy-evidence.md`) and pass it in the prompt.
 
-4. **Spawn 8 persona agents in parallel** as Tasks with subagent_type="general-purpose" and model="opus". Each agent's prompt includes:
+4. **Spawn 8 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. Each agent's prompt includes:
 
-   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `/pony-ref`), read that skill's content and include it in the agent prompt.
-   - The documentation principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project CLAUDE.md if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
+   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `pony-ref`), read that skill's content and include it in the agent prompt.
+   - The documentation principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project AGENTS.md if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
    - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
    - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
    - Relevant gathered context from step 2, distributed to the personas that consume it (e.g. source code for Accuracy; related docs or style guides for Consistency or Principles when they run).
@@ -76,7 +76,7 @@ The pony-synthesize skill's output format is not a natural fit for documentation
 
 5. **Triage agent outputs** per ensemble protocol — check that each persona addressed the actual documentation and stayed coherent.
 
-6. **Pass triaged persona summaries to a synthesis agent** loaded with `/pony-synthesize`, plus the pony-docs-review-specific synthesis focus (below). Provide the paths to each persona's evidence file so the synthesizer can dig in when needed. Instruct the synthesizer to produce its output in the final review format (below) rather than the generic synthesizer format. If this is a re-review (iterative mode), include the full review history: for each prior round, what was found, what was fixed, what was parked. The synthesizer uses this to verify fixes were addressed, avoid re-flagging parked items, and detect convergence failures.
+6. **Pass triaged persona summaries to a synthesis agent** loaded with `pony-synthesize`, plus the pony-docs-review-specific synthesis focus (below). Provide the paths to each persona's evidence file so the synthesizer can dig in when needed. Instruct the synthesizer to produce its output in the final review format (below) rather than the generic synthesizer format. If this is a re-review (iterative mode), include the full review history: for each prior round, what was found, what was fixed, what was parked. The synthesizer uses this to verify fixes were addressed, avoid re-flagging parked items, and detect convergence failures.
 
 7. **Reviewer loop on the synthesis** — the reviewer verifies that no persona findings were dropped, severity changes from individual findings are justified, and cross-persona patterns were correctly identified.
 
@@ -119,7 +119,7 @@ The loop ends when no findings remain except parked and out-of-scope items. At t
 
 ## Process: Lightweight Mode
 
-Lightweight mode runs 3 personas in a single pass with no iterative re-review. Load `/pony-ensemble` for the mechanical process.
+Lightweight mode runs 3 personas in a single pass with no iterative re-review. Load `pony-ensemble` for the mechanical process.
 
 ### Personas
 
@@ -154,10 +154,10 @@ Pick whichever is most relevant to the change. If multiple conditions apply, pic
 
 3. **Create a temporary directory for evidence files.** Use `~/tmp/pony-docs-review-<timestamp>/`. Same convention as full mode.
 
-4. **Spawn 3 persona agents in parallel** as Tasks with subagent_type="general-purpose" and model="opus". Each agent's prompt includes:
+4. **Spawn 3 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. Each agent's prompt includes:
 
    - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill, read that skill's content and include it in the agent prompt.
-   - The documentation principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project CLAUDE.md if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
+   - The documentation principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project AGENTS.md if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
    - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
    - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
    - Relevant gathered context from step 2, distributed to the personas that consume it (e.g. source code for Accuracy; related docs or style guides for Consistency or Principles when they run).
@@ -171,7 +171,7 @@ Pick whichever is most relevant to the change. If multiple conditions apply, pic
 
 5. **Triage agent outputs** per ensemble protocol — check that each persona addressed the actual documentation and stayed coherent.
 
-6. **Pass triaged persona summaries to a synthesis agent** loaded with `/pony-synthesize`, plus the lightweight synthesis focus (below). Provide the paths to each persona's evidence file so the synthesizer can dig in when needed. Instruct the synthesizer to produce its output in the final review format (below) rather than the generic synthesizer format — same override as full mode.
+6. **Pass triaged persona summaries to a synthesis agent** loaded with `pony-synthesize`, plus the lightweight synthesis focus (below). Provide the paths to each persona's evidence file so the synthesizer can dig in when needed. Instruct the synthesizer to produce its output in the final review format (below) rather than the generic synthesizer format — same override as full mode.
 
 7. **Reviewer loop on the synthesis** — same checks as full mode: verify no persona findings were dropped, severity changes from individual findings are justified, and cross-persona patterns were correctly identified.
 

--- a/pony-docs-review/personas/accuracy.md
+++ b/pony-docs-review/personas/accuracy.md
@@ -24,7 +24,7 @@ You verify that the documentation is technically correct. You cross-reference ev
 
 ## Context Loading
 
-- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Review against the documentation principles provided in your prompt, and the project's `AGENTS.md` if it has one
 - Read the source code that the documentation describes — this is your primary verification tool
-- If a Pony project, load `/pony-ref` — the stdlib API surface, common gotchas, and capabilities are especially relevant for verifying documentation accuracy
+- If a Pony project, load `pony-ref` — the stdlib API surface, common gotchas, and capabilities are especially relevant for verifying documentation accuracy
 - Read all changed documentation files in full, not just diffs — accuracy depends on surrounding claims

--- a/pony-docs-review/personas/clarity.md
+++ b/pony-docs-review/personas/clarity.md
@@ -24,7 +24,7 @@ You evaluate whether the documentation communicates its content effectively to t
 
 ## Context Loading
 
-- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Review against the documentation principles provided in your prompt, and the project's `AGENTS.md` if it has one
 - If the project has voice or style guidelines, load them — clarity should be evaluated within the project's established voice, not against a generic standard
 - Read the full changed documentation, not just diffs — clarity depends on surrounding context and flow
 - Identify the target audience from the document's position in the doc set (tutorial vs. reference vs. guide)

--- a/pony-docs-review/personas/completeness.md
+++ b/pony-docs-review/personas/completeness.md
@@ -24,7 +24,7 @@ You trace the reader's path through the documentation and identify where they wo
 
 ## Context Loading
 
-- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Review against the documentation principles provided in your prompt, and the project's `AGENTS.md` if it has one
 - Read the full documentation set (not just changed files) to understand what context exists elsewhere — a concept might be explained in a different page
 - Read source code when checking enumeration completeness (e.g., are all config options documented?)
-- If a Pony project, load `/pony-ref` — the capabilities model, common gotchas, and stdlib pitfalls often require documentation that beginners wouldn't know to look for
+- If a Pony project, load `pony-ref` — the capabilities model, common gotchas, and stdlib pitfalls often require documentation that beginners wouldn't know to look for

--- a/pony-docs-review/personas/consistency.md
+++ b/pony-docs-review/personas/consistency.md
@@ -24,7 +24,7 @@ You verify that the documentation is internally consistent and consistent with t
 
 ## Context Loading
 
-- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Review against the documentation principles provided in your prompt, and the project's `AGENTS.md` if it has one
 - Read existing documentation in the same doc set — this is your primary comparison material. You need to know what conventions exist before you can verify compliance.
 - Check for any explicit style guides, documentation templates, or formatting standards the project maintains
 - Read the full changed documentation, not just diffs — consistency issues often span sections

--- a/pony-docs-review/personas/principles.md
+++ b/pony-docs-review/personas/principles.md
@@ -4,7 +4,7 @@ You systematically verify the documentation against every applicable principle f
 
 ## Core Principles
 
-1. **Use the principles provided to you.** The documentation principles are provided in your prompt, and the project may have its own `CLAUDE.md`. These are your source of truth. Do not work from memory of what they contain.
+1. **Use the principles provided to you.** The documentation principles are provided in your prompt, and the project may have its own `AGENTS.md`. These are your source of truth. Do not work from memory of what they contain.
 
 2. **Enumerate applicable principles.** List every principle that applies to documentation work. A principle applies if it governs documentation practices, writing conventions, or content that documentation should reflect (e.g., "Document public API elements" means you check that documentation covers public API elements).
 
@@ -24,7 +24,7 @@ You systematically verify the documentation against every applicable principle f
 
 ## Context Loading
 
-- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one — this is your primary source material
+- Review against the documentation principles provided in your prompt, and the project's `AGENTS.md` if it has one — this is your primary source material
 - Read all changed documentation files in full
 - Read any style guides, voice guidelines, or documentation conventions the project maintains
 - Read any documentation that the change might affect (cross-references, index pages, navigation)

--- a/pony-docs-review/personas/reader-experience.md
+++ b/pony-docs-review/personas/reader-experience.md
@@ -24,7 +24,7 @@ You evaluate the documentation from the reader's perspective as a holistic journ
 
 ## Context Loading
 
-- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Review against the documentation principles provided in your prompt, and the project's `AGENTS.md` if it has one
 - Read the full document and any prerequisite documents the reader would encounter first — the experience includes the path the reader took to get here
 - Identify the target audience and their expected background from the document's position in the doc set
-- If a Pony project, load `/pony-ref` — reference capabilities are a particularly challenging concept for new Pony users, and documentation that introduces them needs careful experience design
+- If a Pony project, load `pony-ref` — reference capabilities are a particularly challenging concept for new Pony users, and documentation that introduces them needs careful experience design

--- a/pony-docs-review/personas/structure.md
+++ b/pony-docs-review/personas/structure.md
@@ -24,7 +24,7 @@ You evaluate the organization and flow of the documentation. Your scope is infor
 
 ## Context Loading
 
-- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Review against the documentation principles provided in your prompt, and the project's `AGENTS.md` if it has one
 - Read the full document (not just changed sections) to evaluate structure holistically — a change to one section can affect the flow of the whole document
 - Read the broader doc set structure to understand where this document fits and how readers navigate to and from it
 - Check for any documentation conventions (section ordering, heading styles, navigation patterns) the project follows

--- a/pony-docs-review/personas/wildcard.md
+++ b/pony-docs-review/personas/wildcard.md
@@ -24,6 +24,6 @@ These are not principles — you are deliberately unconstrained.
 
 ## Context Loading
 
-- Review against the documentation principles provided in your prompt, and the project's `CLAUDE.md` if it has one
+- Review against the documentation principles provided in your prompt, and the project's `AGENTS.md` if it has one
 - Read all changed documentation files in full
 - Read whatever else catches your attention — you are not constrained to specific files or skills

--- a/pony-docs-review/references/principles.md
+++ b/pony-docs-review/references/principles.md
@@ -1,6 +1,6 @@
 # Documentation Principles
 
-These are the principles this review audits documentation against — a project-agnostic baseline. If the project under review has its own `CLAUDE.md`, style guide, or documentation conventions, audit against those as well; they are usually more specific and take precedence where they conflict with this baseline.
+These are the principles this review audits documentation against — a project-agnostic baseline. If the project under review has its own `AGENTS.md`, style guide, or documentation conventions, audit against those as well; they are usually more specific and take precedence where they conflict with this baseline.
 
 ## Principles
 

--- a/pony-ensemble/SKILL.md
+++ b/pony-ensemble/SKILL.md
@@ -10,8 +10,8 @@ Produce higher-confidence outputs through decorrelated reasoning paths. Multiple
 
 ## Process
 
-1. Spawn one agent per attention focus in parallel, each as a Task with subagent_type="general-purpose" and model="opus". Each agent's prompt must include:
-   - Instructions to read the project CLAUDE.md if applicable and follow its conventions, including loading any skills it references
+1. Spawn one agent per attention focus in parallel, each as a fresh-context sub-agent using your most capable model. Each agent's prompt must include:
+   - Instructions to read the project AGENTS.md if applicable and follow its conventions, including loading any skills it references
    - The task description
    - An attention focus — a short directive that shifts where the agent goes deeper (e.g., "pay particular attention to security implications"). This is a spotlight, not blinders — the agent still covers everything
    - The agent output format (below)
@@ -22,7 +22,7 @@ Produce higher-confidence outputs through decorrelated reasoning paths. Multiple
    - Is the output coherent and complete, or did the agent fail partway through?
    - Are the outputs answering the same question, or did one interpret the task differently?
    If an agent went off-topic or answered the wrong question, either re-prompt it with clarification or exclude its output and note why for the synthesizer. Don't forward garbage to synthesis and hope it sorts itself out.
-3. Pass triaged agent outputs to a synthesis agent loaded with `/pony-synthesize`
+3. Pass triaged agent outputs to a synthesis agent loaded with `pony-synthesize`
 4. Reviewer loop on the synthesis
 5. Present to the human
 

--- a/pony-pbt-patterns/SKILL.md
+++ b/pony-pbt-patterns/SKILL.md
@@ -17,7 +17,7 @@ The job of a good generator is therefore not to be *random* — it is to **struc
 
 This bias matters wherever the code *branches* on a value or *accumulates* state across operations. For a property that holds uniformly across its whole domain — an algebraic law, an encode/decode round-trip — there are no edges to seek out and broad uniform generation is already right. Bias toward where bugs live without starving the ordinary middle, where plenty of logic bugs also sit.
 
-The two scales are cross-cutting lenses, not the document's organizing axis. The patterns below are grouped by the goal you have at the moment: making the generator reach the space chance won't (A), probing a validation boundary precisely (B), and building generators and oracles you can trust (C). They map onto PonyCheck — see `/pony-ref` for its generator API and gotchas.
+The two scales are cross-cutting lenses, not the document's organizing axis. The patterns below are grouped by the goal you have at the moment: making the generator reach the space chance won't (A), probing a validation boundary precisely (B), and building generators and oracles you can trust (C). They map onto PonyCheck — see `pony-ref` for its generator API and gotchas.
 
 ## A. Reach the space chance won't
 

--- a/pony-ref/SKILL.md
+++ b/pony-ref/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pony-ref
-description: Load the Pony language reference (capabilities, PonyCheck, stdlib pitfalls, mort pattern). Use /pony-ref to load before Pony coding sessions.
+description: Load the Pony language reference (capabilities, PonyCheck, stdlib pitfalls, mort pattern). Load it before Pony coding sessions.
 disable-model-invocation: false
 ---
 
@@ -175,7 +175,7 @@ fun gen(): Generator[String] =>
         "my value"
     end)
 ```
-Do NOT try `primitive MyGen is GenObj[String]` or `class MyGen is GenObj[String]` — this is a common Claude mistake that produces confusing compiler errors ("can't find definition of 'T'"), which then gets misattributed to a compiler bug. It's a usage error. Return either a bare value or `(value, shrink_iterator)` tuple from `generate()`.
+Do NOT try `primitive MyGen is GenObj[String]` or `class MyGen is GenObj[String]` — this is a common agent mistake that produces confusing compiler errors ("can't find definition of 'T'"), which then gets misattributed to a compiler bug. It's a usage error. Return either a bare value or `(value, shrink_iterator)` tuple from `generate()`.
 
 **Generator composition**: `.filter()`, `.map()`, `.flat_map()`, `.union()`, plus `Generators.zip2/3/4`, `Generators.map2/3/4`, `Generators.frequency` (weighted selection).
 

--- a/pony-software-design/SKILL.md
+++ b/pony-software-design/SKILL.md
@@ -58,7 +58,7 @@ pattern-match — the disciplines become post-hoc rationalizations for a
 retrieved design rather than actual constraints on the exploration.
 
 The full design process runs in two stages with a feedback loop. Load
-`/pony-ensemble` for the mechanical process; the personas defined in this skill
+`pony-ensemble` for the mechanical process; the personas defined in this skill
 replace the generic attention focuses.
 
 ### Relationship to Ensemble Workflow
@@ -283,7 +283,7 @@ the tensions.
 
 Lightweight mode uses fewer personas and a single pass. It keeps all three
 design personas but reduces evaluation to two personas and drops the
-feedback loop. Load `/pony-ensemble` for the mechanical process.
+feedback loop. Load `pony-ensemble` for the mechanical process.
 
 ### Orchestrator pre-spawn: understand the problem
 
@@ -1267,7 +1267,7 @@ When designing Pony APIs, libraries, or framework features:
   rather than using flags or optional fields. The actor becomes a thin shell
   that delegates to the current state object — state transitions replace
   the object, and the old state's resources are released automatically. See
-  the state machine pattern in `/pony-ref`. Marker primitives with scattered
+  the state machine pattern in `pony-ref`. Marker primitives with scattered
   `match _state` / `if _state is` checks are a step above boolean flags but
   still fragment behavior across the actor's methods — use them only for
   simple guards within a single behavior, not for routing different behavior

--- a/pony-software-design/personas/design/consumer-first.md
+++ b/pony-software-design/personas/design/consumer-first.md
@@ -31,6 +31,6 @@ design — it IS the design.
 
 ## Context Loading
 
-- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `CLAUDE.md` if it has one
+- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `AGENTS.md` if it has one
 - Read all design disciplines in SKILL.md — they all apply
 - Read any existing code the design builds on or interacts with

--- a/pony-software-design/personas/design/principle-checker.md
+++ b/pony-software-design/personas/design/principle-checker.md
@@ -32,7 +32,7 @@ answer for each principle.
 
 - Read the code-design principles in `references/principles.md` (alongside
   this skill) — these are the principles you verify against; the project's
-  `CLAUDE.md` may add more
+  `AGENTS.md` may add more
 - Read all design disciplines in SKILL.md — they all apply, and they're also
   part of what you verify
 - Read any existing code the design references or builds on

--- a/pony-software-design/personas/design/skeptic.md
+++ b/pony-software-design/personas/design/skeptic.md
@@ -50,7 +50,7 @@ the smallest possible design that solves the problem.
 
 ## Context Loading
 
-- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `CLAUDE.md` if it has one
+- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `AGENTS.md` if it has one
 - Read all design disciplines in SKILL.md — they all apply
 - Read existing codebase code relevant to the design — you need to know what
   already exists to avoid reinventing it

--- a/pony-software-design/personas/evaluation/adversarial.md
+++ b/pony-software-design/personas/evaluation/adversarial.md
@@ -48,7 +48,7 @@ structural problem.
 
 ## Context Loading
 
-- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `CLAUDE.md` if it has one
+- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `AGENTS.md` if it has one
 - Read the candidate design from Stage 1 synthesis
 - Read any existing code the design builds on — adversarial analysis requires
   understanding the broader system

--- a/pony-software-design/personas/evaluation/performance.md
+++ b/pony-software-design/personas/evaluation/performance.md
@@ -44,7 +44,7 @@ patterns. You're looking for performance problems baked into the architecture.
 
 ## Context Loading
 
-- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `CLAUDE.md` if it has one
+- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `AGENTS.md` if it has one
 - Read the candidate design from Stage 1 synthesis
-- If a Pony project, load `/pony-ref` — the performance cheat sheet, actor
+- If a Pony project, load `pony-ref` — the performance cheat sheet, actor
   model patterns, and capabilities all affect performance design decisions

--- a/pony-software-design/personas/evaluation/security.md
+++ b/pony-software-design/personas/evaluation/security.md
@@ -50,9 +50,9 @@ bugs in the code.
 
 ## Context Loading
 
-- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `CLAUDE.md` if it has one
+- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `AGENTS.md` if it has one
 - Read the candidate design from Stage 1 synthesis
 - Identify the language and platform to focus on relevant threat models
-- If a Pony project, load `/pony-ref` — FFI boundaries, capability-based
+- If a Pony project, load `pony-ref` — FFI boundaries, capability-based
   security, and actor isolation all have security implications at the design
   level

--- a/pony-software-design/personas/evaluation/testability.md
+++ b/pony-software-design/personas/evaluation/testability.md
@@ -53,6 +53,6 @@ baked into the structure, not gaps in a test suite.
 
 ## Context Loading
 
-- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `CLAUDE.md` if it has one
+- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `AGENTS.md` if it has one
 - Read the candidate design from Stage 1 synthesis
-- Load `/pony-test-design` for additional context on what makes tests meaningful
+- Load `pony-test-design` for additional context on what makes tests meaningful

--- a/pony-software-design/personas/evaluation/wildcard.md
+++ b/pony-software-design/personas/evaluation/wildcard.md
@@ -46,7 +46,7 @@ These are not principles — you are deliberately unconstrained.
 
 ## Context Loading
 
-- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `CLAUDE.md` if it has one
+- Read the code-design principles in `references/principles.md` (alongside this skill) and the project's `AGENTS.md` if it has one
 - Read the candidate design artifacts from stage 1
 - Read whatever else catches your attention — you are not constrained to
   specific files or skills

--- a/pony-software-design/references/principles.md
+++ b/pony-software-design/references/principles.md
@@ -2,7 +2,7 @@
 
 These are the general code-design principles this skill works from — the design personas use them as background, and the principle-checker verifies a design against them. They are a project-agnostic baseline, alongside this skill's own design disciplines (in `SKILL.md`).
 
-If the project being designed for has its own `CLAUDE.md` or other stated conventions, those apply too and take precedence where they conflict with this baseline.
+If the project being designed for has its own `AGENTS.md` or other stated conventions, those apply too and take precedence where they conflict with this baseline.
 
 ## Principles
 

--- a/pony-test-design/SKILL.md
+++ b/pony-test-design/SKILL.md
@@ -47,7 +47,7 @@ makes it bounded and why fewer evaluation personas are sufficient.
 
 ## Process: full mode
 
-Test planning runs in two stages with a feedback loop. Load `/pony-ensemble` for
+Test planning runs in two stages with a feedback loop. Load `pony-ensemble` for
 the mechanical process; the personas defined in this skill replace the generic
 attention focuses.
 
@@ -188,7 +188,7 @@ supports the concern.
 
 Instruct the synthesizer that evaluation findings are independent concerns
 from different analytical lenses, not alternative approaches to the same
-problem. The dominance heuristic from `/pony-synthesize` ("when one agent's output
+problem. The dominance heuristic from `pony-synthesize` ("when one agent's output
 is clearly superior, use it") does not apply — a specificity finding and a
 coverage finding aren't competing, they're additive. Collect all findings for
 categorization.
@@ -274,7 +274,7 @@ rejections, and the tensions.
 
 Lightweight mode uses fewer personas and a single pass. It keeps all three
 planning personas but reduces evaluation to two personas and drops the
-feedback loop. Load `/pony-ensemble` for the mechanical process.
+feedback loop. Load `pony-ensemble` for the mechanical process.
 
 ### Stage 1: Planning
 
@@ -393,7 +393,7 @@ Each test should define its own inputs inline. This makes tests independent — 
 
 ### 4. Properties and Edge Cases
 
-Favor property-based tests over example-based unit tests. An example-based test says "this specific input produces this exact output." A property test says "across many inputs, this invariant holds." Examples test one point; properties test the rule. When a PBT framework isn't available, write the property loop manually — iterate over inputs, collect results, assert the invariant. Load `/pony-pbt-patterns` for generator design and coverage patterns when writing PBT.
+Favor property-based tests over example-based unit tests. An example-based test says "this specific input produces this exact output." A property test says "across many inputs, this invariant holds." Examples test one point; properties test the rule. When a PBT framework isn't available, write the property loop manually — iterate over inputs, collect results, assert the invariant. Load `pony-pbt-patterns` for generator design and coverage patterns when writing PBT.
 
 Use example-based tests for edge cases and boundary conditions. Edges are where bugs live: zero, empty, one element, maximum value, off-by-one at a threshold, the exact boundary between valid and invalid. These deserve explicit tests with known inputs and exact expected outputs because you're testing a specific decision point, not general behavior. Properties and edge-case examples complement each other — properties cover the space, examples nail the borders.
 

--- a/pony-test-design/personas/evaluation/counterfactual.md
+++ b/pony-test-design/personas/evaluation/counterfactual.md
@@ -47,9 +47,9 @@ assertion, see if it fires), catching weak tests before they're implemented.
 
 ## Context Loading
 
-- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
+- Read the project's `AGENTS.md` if it has one, for project-specific conventions
 - Read the candidate test strategy from Stage 1 synthesis
 - Read the code under test — you need to construct plausible mutations
-- If a Pony project, load `/pony-ref`
+- If a Pony project, load `pony-ref`
 - Read the "Magic Values Are Unverified Assumptions" and "Counterfactual
   Testing" disciplines from the pony-test-design SKILL.md for the full context

--- a/pony-test-design/personas/evaluation/coverage.md
+++ b/pony-test-design/personas/evaluation/coverage.md
@@ -46,10 +46,10 @@ provides false confidence — the parts that aren't tested are where bugs hide.
 
 ## Context Loading
 
-- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
+- Read the project's `AGENTS.md` if it has one, for project-specific conventions
 - Read the candidate test strategy from Stage 1 synthesis
 - Read the code under test — you need the decision space to assess coverage
-- If a Pony project, load `/pony-ref`
+- If a Pony project, load `pony-ref`
 - Read the "Each Test Owns Its Inputs", "Properties and Edge Cases", and
   "Consistent Rigor Across Variants" disciplines from the pony-test-design
   SKILL.md for the full context

--- a/pony-test-design/personas/evaluation/property-opportunity.md
+++ b/pony-test-design/personas/evaluation/property-opportunity.md
@@ -29,7 +29,7 @@ to find those invariants and recommend properties.
    whether a useful generator is practical. Some domains have simple
    generators (integers, strings, lists). Others require complex generators
    that are themselves a source of bugs. A property with a bad generator is
-   worse than a good example. Load `/pony-pbt-patterns` for generator strategies.
+   worse than a good example. Load `pony-pbt-patterns` for generator strategies.
 
 5. **Check the valid/invalid/mixed triad.** For any test that validates input,
    check whether the strategy includes the full triad: valid inputs always
@@ -53,10 +53,10 @@ to find those invariants and recommend properties.
 
 ## Context Loading
 
-- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
+- Read the project's `AGENTS.md` if it has one, for project-specific conventions
 - Read the candidate test strategy from Stage 1 synthesis
 - Read the code under test — you need to identify invariants
-- Load `/pony-pbt-patterns` for generator design and coverage patterns
-- If a Pony project, load `/pony-ref`
+- Load `pony-pbt-patterns` for generator design and coverage patterns
+- If a Pony project, load `pony-ref`
 - Read the "Properties and Edge Cases" and "Magic Values Are Unverified
   Assumptions" disciplines from the pony-test-design SKILL.md for the full context

--- a/pony-test-design/personas/evaluation/specificity.md
+++ b/pony-test-design/personas/evaluation/specificity.md
@@ -45,9 +45,9 @@ verify it reaches the developer's code, not just library functions.
 
 ## Context Loading
 
-- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
+- Read the project's `AGENTS.md` if it has one, for project-specific conventions
 - Read the candidate test strategy from Stage 1 synthesis
 - Read the code under test — you need to trace execution paths
-- If a Pony project, load `/pony-ref`
+- If a Pony project, load `pony-ref`
 - Read the "Test the Code You Wrote" and "Test at Integration Boundaries"
   disciplines from the pony-test-design SKILL.md for the full context

--- a/pony-test-design/personas/evaluation/wildcard.md
+++ b/pony-test-design/personas/evaluation/wildcard.md
@@ -50,7 +50,7 @@ These are not principles — you are deliberately unconstrained.
 
 ## Context Loading
 
-- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
+- Read the project's `AGENTS.md` if it has one, for project-specific conventions
 - Read the candidate test strategy from Stage 1 synthesis
 - Read whatever else catches your attention — you are not constrained to
   specific files or skills

--- a/pony-test-design/personas/planning/boundary-focused.md
+++ b/pony-test-design/personas/planning/boundary-focused.md
@@ -38,7 +38,7 @@ actually does, not what it's supposed to do.
 
 ## Context Loading
 
-- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
+- Read the project's `AGENTS.md` if it has one, for project-specific conventions
 - Read all pony-test-design disciplines in SKILL.md — they all apply
 - Read the code under test — you need the implementation to map boundaries
-- If a Pony project, load `/pony-ref`
+- If a Pony project, load `pony-ref`

--- a/pony-test-design/personas/planning/contract-focused.md
+++ b/pony-test-design/personas/planning/contract-focused.md
@@ -56,8 +56,8 @@ bring is the outside-in perspective.
 
 ## Context Loading
 
-- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
+- Read the project's `AGENTS.md` if it has one, for project-specific conventions
 - Read all pony-test-design disciplines in SKILL.md — they all apply
 - Read the public API of the code under test — types, signatures, docstrings
 - Do NOT read the implementation until after planning (step 7)
-- If a Pony project, load `/pony-ref`
+- If a Pony project, load `pony-ref`

--- a/pony-test-design/personas/planning/failure-focused.md
+++ b/pony-test-design/personas/planning/failure-focused.md
@@ -43,8 +43,8 @@ paths.
 
 ## Context Loading
 
-- Read the project's `CLAUDE.md` if it has one, for project-specific conventions
+- Read the project's `AGENTS.md` if it has one, for project-specific conventions
 - Read all pony-test-design disciplines in SKILL.md — they all apply
 - Read the code under test — you need to understand what can go wrong
 - Read any error types or error handling patterns in the codebase
-- If a Pony project, load `/pony-ref`
+- If a Pony project, load `pony-ref`


### PR DESCRIPTION
These skills started life as Claude Code skills, but the methodology ones — the ensemble reviews, the design and test disciplines — were never really Claude-specific. The repo just hadn't caught up.

Now you can install and use them with OpenAI Codex too. Run `python install.py` and it detects which agents you have (Claude Code, Codex, or both) and installs the skills where each one reads them: `~/.claude/skills` and `~/.agents/skills`. Pass `--claude` or `--codex` to pick one yourself.

The skill content is harness-neutral now. References to a project's conventions point at `AGENTS.md`, the agent-spawning instructions no longer name a specific tool's API, and the invocation syntax isn't assumed to be Claude's slash commands. Same guidance, whichever agent reads it.