### PR TITLE
Split project instructions into AGENTS.md with a CLAUDE.md shim

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,4 @@
 pony-*/
+AGENTS.md
+CLAUDE.md
 CODE_OF_CONDUCT.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Pony LLM Skills — project instructions
+
+Instructions for working in this repository.
+
+## Pull requests
+
+**On a changelog-labeled PR, write the description like a release note.** A PR carrying a `changelog - *` label documents a user-facing change, and the generated CHANGELOG entry links readers straight to the PR — so the PR description is what a reader lands on. Write it for the person *using* the skills, not for someone reading the implementation: plain language, the user-visible impact, and why it matters — not an enumeration of the internal mechanics. Keep it short. (Example — PR #36's description read: The code review skill was pointing at my personal CLAUDE.md to get information which made it perform "subpar" when others used it.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,1 @@
-# Pony LLM Skills — project instructions
-
-Instructions for working in this repository.
-
-## Pull requests
-
-**On a changelog-labeled PR, write the description like a release note.** A PR carrying a `changelog - *` label documents a user-facing change, and the generated CHANGELOG entry links readers straight to the PR — so the PR description is what a reader lands on. Write it for the person *using* the skills, not for someone reading the implementation: plain language, the user-visible impact, and why it matters — not an enumeration of the internal mechanics. Keep it short. (Example — PR #36's description read: The code review skill was pointing at my personal CLAUDE.md to get information which made it perform "subpar" when others used it.)
+@AGENTS.md


### PR DESCRIPTION
Moves this repo's contributor/agent instructions out of `CLAUDE.md` into a new `AGENTS.md`, and turns `CLAUDE.md` into a one-line `@AGENTS.md` import — the same split ponyc and other ponylang repos use.

`AGENTS.md` is the harness-neutral standard the org is standardizing on, and it's what sub-agents and non-Claude tools read directly. Keeping a `CLAUDE.md` that `@`-imports it means Claude Code still loads the instructions as memory. The content is moved verbatim.

Both `CLAUDE.md` and `AGENTS.md` are added to `.markdownlintignore`, matching ponyc. `CLAUDE.md` must be ignored because the bare `@AGENTS.md` line isn't a heading and trips markdownlint's MD041.