### PR TITLE
Add a contributor-only block to AGENTS.md pointing at CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 Instructions for working in this repository.
 
+<!-- contributor-only -->
+## Contributing
+
+Before contributing to this repository, read [CONTRIBUTING.md](CONTRIBUTING.md).
+<!-- /contributor-only -->
+
 ## Pull requests
 
 **On a changelog-labeled PR, write the description like a release note.** A PR carrying a `changelog - *` label documents a user-facing change, and the generated CHANGELOG entry links readers straight to the PR — so the PR description is what a reader lands on. Write it for the person *using* the skills, not for someone reading the implementation: plain language, the user-visible impact, and why it matters — not an enumeration of the internal mechanics. Keep it short. (Example — PR #36's description read: The code review skill was pointing at my personal CLAUDE.md to get information which made it perform "subpar" when others used it.)


### PR DESCRIPTION
Adds a `<!-- contributor-only -->` block near the top of `AGENTS.md` that points contributors to `CONTRIBUTING.md`, following the same convention ponyc uses.

The marker comments mean an assistant that already has the org's global setup skips the block, while an outside contributor (or their assistant) arriving with no setup is sent to `CONTRIBUTING.md`. It's deliberately minimal — ponyc's version also tells contributors to install the llm-skills and load the `pony-skills` skill, but here that would be circular since this repo *is* the skills source.