### PR TITLE
Clarify literal-path requirement in pony-code-review tmp dir step

### DIFF
--- a/pony-code-review/SKILL.md
+++ b/pony-code-review/SKILL.md
@@ -79,7 +79,7 @@ When principles conflict, these values set the priority. We value the left side 
 
 2. **Build and run tests once.** Capture the build output and test results. These results are provided to persona agents that need them — no agent runs tests itself. If the build fails or tests fail, proceed with the review anyway — provide the failure output to all personas and note whether the failure is pre-existing or introduced by the change.
 
-3. **Create a temporary directory for evidence files.** Use `~/tmp/code-review-<timestamp>/`. Each persona will write its detailed evidence to a file in this directory. Generate the file path for each persona (e.g., `correctness-evidence.md`) and pass it in the prompt.
+3. **Create a temporary directory for evidence files.** Use `~/tmp/code-review-<timestamp>/`, where `<timestamp>` is seconds-precision (e.g., `2026-06-05-143052`). Pick a concrete path up front — substitute a real timestamp for `<timestamp>` and reuse that literal path verbatim in every subsequent step. Each shell command runs in a fresh process, so don't try to recompute the path. Each persona will write its detailed evidence to a file in this directory. Generate the file path for each persona (e.g., `correctness-evidence.md`) and pass it in the prompt.
 
 4. **Spawn 8 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. Each agent's prompt includes:
 


### PR DESCRIPTION
## Context

The full-mode step that creates the evidence directory reads `Use ~/tmp/code-review-<timestamp>/`. The placeholder is ambiguous in two ways:

- `<timestamp>` has no specified precision, so an agent can reasonably pick `2026-06-05` (day) or `2026-06-05-143052` (second). Day-precision risks collisions across same-day reviews.
- The instruction reads as if `<timestamp>` is something to expand at call time. Agents regularly respond by generating a timestamp inline with `$(date ...)` in the `mkdir`, then trying to recover the path in later steps with patterns like `ls -d ~/tmp/code-review-*/ | tail -1`. That `ls` returns the alphabetically last matching directory, which is a *different* directory whenever an older run left one behind or a concurrent run created a later-sorting one — so subsequent persona spawns and evidence writes land in the wrong place.

Lightweight mode defers to full mode via `Same convention as full mode.`, so any ambiguity in full mode propagates.

## Changes

- Pin seconds-precision in the placeholder, with a concrete example (`2026-06-05-143052`).
- Tell the orchestrator to substitute a real timestamp for `<timestamp>` up front and reuse the literal path verbatim in every subsequent step.
- Note that shell commands run in fresh processes, so the path must not be recomputed.

## Considerations

- The new wording is intended to eliminate the `$(date ...)` + `ls | tail -1` workaround without naming the anti-pattern explicitly. An orchestrator that follows "substitute a real timestamp and reuse the literal verbatim" has no reason to compute the timestamp in a subshell or recover it after the fact. If this turns out not to be sufficient in practice, a follow-up can call the anti-pattern out by name.
- Wording is harness-neutral ("shell command", "fresh process") — no Claude- or Codex-specific tool names introduced.
- Lightweight mode's step 3 was left alone; `Same convention as full mode.` continues to point at the right thing now that full mode is unambiguous.
- An existence check on the directory was considered and rejected: seconds-precision plus a fresh timestamp per run make collisions improbable, and the residual risk is accepted as low.