### PR TITLE
Add pony-vet-suspected-issues skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ Has full (8-persona, iterative re-review) and lightweight (3-persona, single pas
 
 Ensemble documentation review — the prose counterpart to `pony-code-review`. Load it when reviewing a documentation-only change (tutorials, READMEs, reference pages). Has full (8-persona, iterative re-review) and lightweight (3-persona, single pass) modes; personas cover accuracy, completeness, clarity, structure, consistency, reader experience, principles, and wildcard concerns.
 
+#### pony-vet-suspected-issues
+
+How to handle a problem you find outside the change you're working on — the bug you noticed in passing, or the out-of-scope finding a review turned up. Load it when you spot one, or when a PR is open and you have some to work through.
+
+Instead of filing an issue on the spot, you capture it as a suspected issue and vet it after the PR is open: verify it, find its real scope, check for duplicates, and review the draft before filing — or discard it. `pony-code-review` and `pony-docs-review` route their out-of-scope findings here.
+
 #### pony-test-design
 
 Two-stage ensemble for planning meaningful tests. Load it when writing tests for new features or reviewing test quality. Counters the tendency to write tests that exercise the stdlib instead of your code.
@@ -203,6 +209,10 @@ Prefer to pick individually? Add any of these instead:
 ### pony-docs-review trigger
 
 > **Load `pony-docs-review` for documentation reviews**: When reviewing a documentation-only change (tutorials, READMEs, reference pages), load `pony-docs-review`. Not for one-line typo or formatting fixes.
+
+### pony-vet-suspected-issues trigger
+
+> **Load `pony-vet-suspected-issues` for problems found outside the current change**: When you spot a bug or gap outside the change you're working on, or a review surfaces an out-of-scope finding, capture it as a suspected issue and vet it after the PR is open before filing — don't file on the spot. Load `pony-vet-suspected-issues`.
 
 ### pony-test-design trigger
 

--- a/pony-code-review/SKILL.md
+++ b/pony-code-review/SKILL.md
@@ -112,7 +112,7 @@ The implementer categorizes each finding. Every finding must be categorized — 
 
 - **Fix**: The right action is obvious from the finding itself. Bugs, missing tests, stale docs, pattern violations, naming issues. Fix without waiting for the human.
 - **Park**: The finding needs the human's input. Design questions, principle tensions, ambiguous tradeoffs where reasonable people could disagree. Also park findings you disagree with — don't dismiss them. Parked items are listed in the PR for the human to weigh in on.
-- **Out of scope**: The finding is real but exists in code that isn't part of the current change. Don't fix it in this PR — file a GitHub issue to track it. Before filing, search existing issues to avoid duplicates. The issue should include the finding, its location, the evidence, and which persona(s) flagged it. These issues ensure that problems discovered during review are tracked even when they can't be addressed in the current change.
+- **Out of scope**: The finding is real but exists in code that isn't part of the current change. Don't fix it in this PR, and don't file an issue for it on the spot. Capture it as a suspected issue — carry the finding, its location, the evidence, and which persona(s) flagged it — and vet it after this PR is open before filing: confirm it still holds, find its real scope, check for duplicates, and review the draft. Load `pony-vet-suspected-issues` for the procedure. Filing straight from a review tends to produce issues that are wrong or miss the real scope; the persona's evidence is the starting point for vetting, not the finished issue.
 
 ### Re-review After Fixes
 
@@ -135,7 +135,7 @@ The structural question should be specific: name the data structure or abstracti
 
 ### Loop Termination
 
-The loop ends when no findings remain except parked and out-of-scope items. At that point, open the PR with the parked items listed in the PR description or as a PR comment so the human can weigh in — never in commit messages. Commit messages are for change rationale only; parked items are transient review artifacts that don't belong in git history. If the human's direction on parked items requires changes, make them and run a final pony-code-review pass to confirm.
+The loop ends when no findings remain except parked and out-of-scope items (the out-of-scope findings are held as suspected issues to vet after the PR, not filed now — see the triage above). At that point, open the PR with the parked items listed in the PR description or as a PR comment so the human can weigh in — never in commit messages. Commit messages are for change rationale only; parked items are transient review artifacts that don't belong in git history. If the human's direction on parked items requires changes, make them and run a final pony-code-review pass to confirm.
 
 ## Process: Lightweight Mode
 
@@ -203,7 +203,7 @@ Same categories as full mode:
 
 - **Fix**: Obvious action from the finding itself. Fix without waiting.
 - **Park**: Needs the human's input. Listed in the PR.
-- **Out of scope**: Real but in code outside this change. File a GitHub issue.
+- **Out of scope**: Real but in code outside this change. Capture it as a suspected issue and vet it after the PR before filing — load `pony-vet-suspected-issues`; don't file on the spot.
 
 No re-review loop. Fix the findings and proceed to opening the PR.
 
@@ -221,7 +221,7 @@ The synthesizer should pay special attention to:
 - **Cross-persona corroboration**: When multiple personas independently flag the same issue from different angles, that's high confidence. Call it out.
 - **Wildcard findings**: The wildcard persona deliberately looks for things the other personas miss. Its findings may be unconventional — evaluate them on merit, not on whether they fit a category. If a wildcard finding aligns with a faint signal from another persona, that's strong evidence both caught the same thing from different angles.
 - **Convergence failures** (re-reviews only): Check the review history for signs that an area isn't converging — recurring findings in the same location, fixes that add complexity instead of removing it, different symptoms of the same structural mismatch across rounds. When detected, escalate a specific structural question (see "Convergence Failure Detection" in the iterative workflow section). This is always a parked item.
-- **Pre-existing issues**: Findings about problems in code outside the current change are still findings — never silently discard them. Flag them clearly as pre-existing so the implementer can triage them as "out of scope" and file issues. A review that discovers a real problem and then drops it because "it's not part of this PR" has wasted the discovery.
+- **Pre-existing issues**: Findings about problems in code outside the current change are still findings — never silently discard them. Flag them clearly as pre-existing so the implementer can triage them as "out of scope" and capture them as suspected issues to vet after the PR. A review that discovers a real problem and then drops it because "it's not part of this PR" has wasted the discovery.
 - **When digging deeper**: Work from the summaries by default. Read the evidence files when a finding needs more context — when severities conflict, when a finding's summary is ambiguous, or when you need to verify the evidence supports the claim.
 
 ## Synthesis Focus: Lightweight Mode

--- a/pony-docs-review/SKILL.md
+++ b/pony-docs-review/SKILL.md
@@ -92,7 +92,7 @@ The implementer categorizes each finding. Every finding must be categorized — 
 
 - **Fix**: The right action is obvious from the finding itself. Factual errors, broken examples, missing steps, stale cross-references, terminology inconsistencies. Fix without waiting.
 - **Park**: The finding needs the maintainer's input. Tone questions, scope decisions, audience disagreements, ambiguous tradeoffs where reasonable people could disagree. Also park findings you disagree with — don't dismiss them. Parked items are listed in the PR for the maintainer to weigh in on.
-- **Out of scope**: The finding is real but exists in documentation that isn't part of the current change. Don't fix it in this PR — file a GitHub issue to track it. Before filing, search existing issues to avoid duplicates. The issue should include the finding, its location, the evidence, and which persona(s) flagged it.
+- **Out of scope**: The finding is real but exists in documentation that isn't part of the current change. Don't fix it in this PR, and don't file an issue for it on the spot. Capture it as a suspected issue — carry the finding, its location, the evidence, and which persona(s) flagged it — and vet it after this PR is open before filing: confirm it still holds, find its real scope, check for duplicates, and review the draft. Load `pony-vet-suspected-issues` for the procedure. Filing straight from a review tends to produce issues that are wrong or miss the real scope; the persona's evidence is the starting point for vetting, not the finished issue.
 
 ### Re-review After Fixes
 
@@ -115,7 +115,7 @@ The structural question should be specific: name the section, describe the patte
 
 ### Loop Termination
 
-The loop ends when no findings remain except parked and out-of-scope items. At that point, open the PR with the parked items listed in the PR description or as a PR comment so the maintainer can weigh in — never in commit messages. Commit messages are for change rationale only; parked items are transient review artifacts that don't belong in git history. If the maintainer's direction on parked items requires changes, make them and run a final pony-docs-review pass to confirm.
+The loop ends when no findings remain except parked and out-of-scope items (the out-of-scope findings are held as suspected issues to vet after the PR, not filed now — see the triage above). At that point, open the PR with the parked items listed in the PR description or as a PR comment so the maintainer can weigh in — never in commit messages. Commit messages are for change rationale only; parked items are transient review artifacts that don't belong in git history. If the maintainer's direction on parked items requires changes, make them and run a final pony-docs-review pass to confirm.
 
 ## Process: Lightweight Mode
 
@@ -183,7 +183,7 @@ Same categories as full mode:
 
 - **Fix**: Obvious action from the finding itself. Fix without waiting.
 - **Park**: Needs the human's input. Listed in the PR.
-- **Out of scope**: Real but in documentation outside this change. File a GitHub issue.
+- **Out of scope**: Real but in documentation outside this change. Capture it as a suspected issue and vet it after the PR before filing — load `pony-vet-suspected-issues`; don't file on the spot.
 
 No re-review loop. Fix the findings and proceed to opening the PR.
 
@@ -200,7 +200,7 @@ The synthesizer should pay special attention to:
 - **Cross-persona corroboration**: When multiple personas independently flag the same issue from different angles, that's high confidence. Call it out.
 - **Wildcard findings**: The wildcard persona deliberately looks for things the other personas miss. Its findings may be unconventional — evaluate them on merit, not on whether they fit a category. If a wildcard finding aligns with a faint signal from another persona, that's strong evidence both caught the same thing from different angles.
 - **Convergence failures** (re-reviews only): Check the review history for signs that an area isn't converging — recurring findings in the same section, fixes that add complexity instead of clarifying, different symptoms of the same structural issue across rounds. When detected, escalate a specific structural question (see "Convergence Failure Detection" in the iterative workflow section). This is always a parked item.
-- **Pre-existing issues**: Findings about problems in documentation outside the current change are still findings — never silently discard them. Flag them clearly as pre-existing so the implementer can triage them as "out of scope" and file issues. A review that discovers a real problem and then drops it because "it's not part of this PR" has wasted the discovery.
+- **Pre-existing issues**: Findings about problems in documentation outside the current change are still findings — never silently discard them. Flag them clearly as pre-existing so the implementer can triage them as "out of scope" and capture them as suspected issues to vet after the PR. A review that discovers a real problem and then drops it because "it's not part of this PR" has wasted the discovery.
 - **When digging deeper**: Work from the summaries by default. Read the evidence files when a finding needs more context — when severities conflict, when a finding's summary is ambiguous, or when you need to verify the evidence supports the claim.
 
 ## Synthesis Focus: Lightweight Mode

--- a/pony-skills/SKILL.md
+++ b/pony-skills/SKILL.md
@@ -14,6 +14,7 @@ When one of these applies, load the named skill.
 | Designing APIs, types, features, or system boundaries (not just implementing an existing design) | `pony-software-design` |
 | Reviewing code, or before opening a PR | `pony-code-review` |
 | Reviewing a documentation-only change | `pony-docs-review` |
+| Handling a problem found outside the current change — capture it, then vet before filing an issue | `pony-vet-suspected-issues` |
 | Writing tests, or assessing test quality | `pony-test-design` |
 | Writing property-based or generative tests | `pony-pbt-patterns` |
 | Before forming a hypothesis about a non-trivial bug | `pony-debug` |

--- a/pony-vet-suspected-issues/SKILL.md
+++ b/pony-vet-suspected-issues/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: pony-vet-suspected-issues
+description: How to handle a problem you spot while working on something else — capture it as a suspected issue instead of filing on the spot, then after the current PR is open, vet each one (verify, scope, review) and file a correct issue or discard it. Load when you find an incidental, out-of-scope problem mid-task, when a code or docs review surfaces an out-of-scope finding, or when the PR is open and you have suspected issues to work through.
+disable-model-invocation: false
+---
+
+# Vet Suspected Issues
+
+When you spot a problem in code or documentation that is outside the change you are working on, do not file an issue for it on the spot. Write it down as a suspected issue and keep going. After the current PR is open, vet each one — verify it, scope it, review it — and only then file an issue, or discard it with a reason.
+
+The reason for the deferral: issues filed on the spot are often wrong or incomplete. You file them from a single observation while loaded on the work at hand, without confirming the problem holds, finding its real scope, searching for duplicates, or reviewing the issue itself. Moving the work to a phase with full attention and real verification is what makes the issue correct.
+
+## Where suspected issues come from
+
+Two sources:
+
+- **You notice something while working** — an unrelated bug, a stale comment, a gap — in code or docs that is not part of your change.
+- **A review surfaces an out-of-scope finding** — `pony-code-review` and `pony-docs-review` route findings that are real but live outside the current change here, instead of filing them mid-review. These arrive with the persona's evidence and which persona flagged it. That evidence is the starting point for vetting, not a finished issue.
+
+## Suspected issues are not parked items
+
+Keep the two apart. A **parked item** is a decision that needs the human's input on the current change; it waits for the human and is listed in the PR. A **suspected issue** is a problem outside the current change that you vet yourself and then file or discard.
+
+## Capture (while working)
+
+When you notice an out-of-scope problem, do not investigate it and do not file it. Add it to a suspected-issue list and keep moving. Each entry records enough to vet it later without rediscovering it:
+
+- What you saw, and where (`file:line`).
+- What you were doing when you noticed it.
+- Your initial hypothesis — marked as a hypothesis, not a conclusion.
+
+Capture bar: a concrete problem you can point at. A vague "this could be nicer" does not go on the list.
+
+Keep the list with the working session, alongside whatever you are already tracking for the current change. When the PR opens, surface the open suspected issues so the vetting phase works from them and a long session doesn't lose them.
+
+## Vet (after the current PR is open)
+
+Run this after the current PR is open, as its own closing phase — not while the main work is in flight. It is not a side quest. (If a suspected issue turns out to be part of the current change after all, it stops being one and folds into that work instead.)
+
+Lock down each suspected issue. Default to the lightweight path; escalate when one is bigger than it looked.
+
+1. **Verify it's real.** Spawn a fresh-context agent. Give it the suspected issue — the observation, the location, your hypothesis — and have it read the actual code and judge whether the problem is real, from evidence rather than argument. For a behavioral bug, verifying means reproducing it (load `pony-debug`). If the suspected issue came from a review persona, you already have its evidence: confirm it still holds and build on it, rather than re-deriving the finding from scratch. Outcomes:
+   - **Confirmed** — continue.
+   - **Not a problem** — discard it and record why. This is a real outcome, not a failure. It is the wrong issue caught before it ships.
+   - **Needs more information** — dig until you can confirm or discard.
+2. **Find the true scope and root cause.** One instance or a pattern? What is the actual extent? A premature issue describes one symptom; vetting finds the whole shape. This is what stops issues from missing points.
+3. **Check for duplicates.** Search the existing issues so you do not file one that is already there.
+4. **Draft the issue.** Follow the project's issue conventions. Keep the body about the problem itself — the symptom, where it lives, the evidence, the scope — not about the review or how the issue came to be filed. Set whatever issue type or labels the project uses.
+5. **Review the draft.** A fresh-context reviewer checks that the claim holds, the scope is right, and nothing is missing. This is the direct fix for issues that miss points.
+6. **File it.**
+
+**Escalate** from the lightweight path to a heavier review when a suspected issue turns out to be a pattern across the codebase or a design problem rather than a single bug — load `pony-code-review` for code, `pony-software-design` for a design problem.
+
+If vetting a suspected issue surfaces a question that is the human's to decide — a design call, an ambiguous tradeoff — it stops being a suspected issue and becomes a parked item for the human, rather than being forced into an issue.
+
+**Fast path:** a problem with nothing behavioral to verify — a typo, a stale comment — skips the reproduction in step 1. Give it a light check and file. Anything that claims a bug or a behavior takes the full path. "It's obviously fine to skip" is exactly the judgment that produces wrong issues.


### PR DESCRIPTION
A new skill, `pony-vet-suspected-issues`, for handling a problem the agent spots outside the change it's working on.

Until now, when `pony-code-review` or `pony-docs-review` found a real problem outside the current change, it told the agent to file a GitHub issue on the spot. Those issues are often wrong or incomplete — filed from a single observation, without confirming the problem holds, finding its real scope, or reviewing the issue itself.

Now the review skills capture those out-of-scope findings as suspected issues instead. After the PR is open, the agent vets each one — verifies it, finds its real scope, checks for duplicates, reviews the draft — and then files a correct issue or discards it. The skill also covers problems the agent notices in passing during any Pony work, not just review findings.
