### PR TITLE
New pony-code-review editor persona

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Has full (8-persona) and lightweight (5-persona) modes. Full mode runs design (3
 
 Ensemble code review with specialized reviewer personas. Load it when conducting a code review of a PR, branch, or local changes.
 
-Has full (8-persona, iterative re-review) and lightweight (3-persona, single pass) modes. Personas cover correctness, security, performance, API design, test quality, adversarial scenarios, design principles, and wildcard concerns.
+Has full (9-persona, iterative re-review) and lightweight (3-persona, single pass) modes. Personas cover correctness, security, performance, API design, test quality, adversarial scenarios, design principles, comment and docstring economy, and wildcard concerns.
 
 #### pony-docs-review
 

--- a/pony-code-review/SKILL.md
+++ b/pony-code-review/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: pony-code-review
-description: Ensemble code review with specialized reviewer personas. Has full (8-persona) and lightweight (3-persona) modes. Load when conducting a code review of a PR, branch, or local changes.
+description: Ensemble code review with specialized reviewer personas. Has full (9-persona) and lightweight (3-persona) modes. Load when conducting a code review of a PR, branch, or local changes.
 disable-model-invocation: false
 ---
 
 # Code Review
 
-Ensemble code review that synthesizes findings from specialized reviewer personas. Has two modes: full (8 personas, iterative re-review) and lightweight (3 personas, single pass). Not for one-line config changes or typo fixes — ask permission to skip review for those.
+Ensemble code review that synthesizes findings from specialized reviewer personas. Has two modes: full (9 personas, iterative re-review) and lightweight (3 personas, single pass). Not for one-line config changes or typo fixes — ask permission to skip review for those.
 
 ## Mode Selection
 
@@ -29,7 +29,7 @@ The skill has two modes: **full** and **lightweight**. The orchestrator selects 
 
 When in doubt, use full mode. Lightweight is appropriate when the change is clearly bounded — the orchestrator should be able to state what makes it bounded and why fewer personas are sufficient.
 
-Note: the pony-software-design skill's lightweight mode follows a similar pattern (mode selection, single pass, escalation) but reduces differently — it has two stages and shrinks only the evaluation stage (5→2 personas). Code-review has a single stage, so the reduction is in persona count (8→3). The shared pattern is the mode selection and escalation structure.
+Note: the pony-software-design skill's lightweight mode follows a similar pattern (mode selection, single pass, escalation) but reduces differently — it has two stages and shrinks only the evaluation stage (5→2 personas). Code-review has a single stage, so the reduction is in persona count (9→3). The shared pattern is the mode selection and escalation structure.
 
 ## Invocation Modes
 
@@ -41,7 +41,7 @@ These modes apply to both full and lightweight:
 
 ## Relationship to Ensemble Workflow
 
-Use the ensemble workflow with review-specific customizations. Load `pony-ensemble` for the mechanical process. This skill replaces the generic attention focuses with review personas (8 for full mode, 3 for lightweight) and replaces the generic agent output format with the review-specific format defined below.
+Use the ensemble workflow with review-specific customizations. Load `pony-ensemble` for the mechanical process. This skill replaces the generic attention focuses with review personas (9 for full mode, 3 for lightweight) and replaces the generic agent output format with the review-specific format defined below.
 
 The Adversarial persona satisfies the ensemble's "fix reviews require an adversarial focus" requirement — when the review target is a fix, the Adversarial persona naturally focuses on showing the fix is incomplete per its identity statement.
 
@@ -81,7 +81,7 @@ When principles conflict, these values set the priority. We value the left side 
 
 3. **Create a temporary directory for evidence files.** Use `~/tmp/code-review-<timestamp>/`, where `<timestamp>` is seconds-precision (e.g., `2026-06-05-143052`). Pick a concrete path up front — substitute a real timestamp for `<timestamp>` and reuse that literal path verbatim in every subsequent step. Each shell command runs in a fresh process, so don't try to recompute the path. Each persona will write its detailed evidence to a file in this directory. Generate the file path for each persona (e.g., `correctness-evidence.md`) and pass it in the prompt.
 
-4. **Spawn 8 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. Each agent's prompt includes:
+4. **Spawn 9 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. Each agent's prompt includes:
 
    - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `pony-test-design`, `pony-pbt-patterns`, `pony-ref`), read that skill's content and include it in the agent prompt.
    - The code-review principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project `AGENTS.md` if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
@@ -92,7 +92,7 @@ When principles conflict, these values set the priority. We value the left side 
    - Instructions to run a reviewer loop before returning — the reviewer checks the persona's analysis for coherence, completeness, and evidence quality, not the underlying code a second time.
    - Instructions that this is an ensemble agent — return findings to the orchestrator, don't take external actions.
 
-   **For the Wildcard persona specifically:** include the identity statement (first paragraph) from each of the other 7 personas so the wildcard knows what territory is already covered.
+   **For the Wildcard persona specifically:** include the identity statement (first paragraph) from each of the other 8 personas so the wildcard knows what territory is already covered.
 
 5. **Triage agent outputs** per ensemble protocol — check that each persona addressed the actual code and stayed coherent.
 
@@ -164,6 +164,7 @@ Pick whichever is most relevant to the change. If multiple conditions apply, pic
 **Not included in lightweight:**
 
 - **Principles** — a fresh-context principle check adds diminishing value on small changes. If the change is large enough to benefit from it, it's large enough for full mode.
+- **Editor** — comment and docstring economy is low-severity on a small, bounded change, and lightweight runs no leaked-artifact sweep either. Both are acceptable to forgo here: a bounded change rarely touches user-facing docs. A change that *does* touch README, CHANGELOG, or public-API docstrings — where a leaked artifact would ship — is a signal toward full mode, not a reason to add the persona to lightweight.
 - **Wildcard** — the wildcard's value scales with change complexity and the number of other personas whose territory it needs to look beyond. With only 3 focused personas on a small change, there's insufficient covered territory for the wildcard to add meaningful signal.
 
 ### Steps
@@ -219,6 +220,7 @@ The synthesizer should pay special attention to:
 - **Test gaps matching other findings**: When the Tests persona identifies coverage gaps that align with issues found by Adversarial or Correctness, those are the highest-priority test additions.
 - **Principle violations others missed**: Findings from the Principles persona that no other persona noticed represent systematic blind spots.
 - **Cross-persona corroboration**: When multiple personas independently flag the same issue from different angles, that's high confidence. Call it out.
+- **Editor findings**: Most are Low — concision and tidiness. But a leaked internal review artifact (finding ID, round marker, sketch/plan backref) in a published or user-facing file, or a stale comment that actively misleads, is a real defect — don't downgrade it as "just style."
 - **Wildcard findings**: The wildcard persona deliberately looks for things the other personas miss. Its findings may be unconventional — evaluate them on merit, not on whether they fit a category. If a wildcard finding aligns with a faint signal from another persona, that's strong evidence both caught the same thing from different angles.
 - **Convergence failures** (re-reviews only): Check the review history for signs that an area isn't converging — recurring findings in the same location, fixes that add complexity instead of removing it, different symptoms of the same structural mismatch across rounds. When detected, escalate a specific structural question (see "Convergence Failure Detection" in the iterative workflow section). This is always a parked item.
 - **Pre-existing issues**: Findings about problems in code outside the current change are still findings — never silently discard them. Flag them clearly as pre-existing so the implementer can triage them as "out of scope" and capture them as suspected issues to vet after the PR. A review that discovers a real problem and then drops it because "it's not part of this PR" has wasted the discovery.
@@ -285,7 +287,7 @@ Confidence calibration: **High** = verified by reading code or running tests. **
 
 ## Personas
 
-The persona documents are in `personas/`. Full mode uses all 8; lightweight uses Correctness + Adversarial + one context-dependent persona (see "Process: Lightweight Mode" for selection criteria).
+The persona documents are in `personas/`. Full mode uses all 9; lightweight uses Correctness + Adversarial + one context-dependent persona (see "Process: Lightweight Mode" for selection criteria).
 
 | File | Focus |
 |------|-------|
@@ -296,4 +298,5 @@ The persona documents are in `personas/`. Full mode uses all 8; lightweight uses
 | `performance.md` | Architectural bottlenecks, then local waste |
 | `tests.md` | Test quality, missing tests, counterfactual reasoning |
 | `principles.md` | Systematic principles audit with evidence |
+| `editor.md` | Comment and docstring economy, leaked-artifact sweep |
 | `wildcard.md` | Chaos agent — finds what the others miss |

--- a/pony-code-review/personas/editor.md
+++ b/pony-code-review/personas/editor.md
@@ -1,0 +1,29 @@
+# Editor Reviewer
+
+You are the ruthless editor. You treat every comment in the changed code as a liability until proven otherwise: comments rot, mislead once they go stale, and bury the few that matter. Your default recommendation is to cut a comment unless a maintainer would write it again today, from scratch — but docstrings are the exception: you tighten them, never delete them. You don't author comments, you don't flag *missing* docs (Principles owns that), and you don't review behavior (Correctness and Adversarial own that).
+
+## Core Principles
+
+1. **Default to cut.** Flag any comment that doesn't earn its keep — one a maintainer wouldn't write again today from scratch. Keep it, collapsed, only when a future reader would re-derive the same comment after one debugging session.
+
+2. **Flag wordy multi-line inline comments for collapsing.** An inline comment (`//` or `/* */` inside a method body or above a statement) that sprawls across several lines drifts out of sync with the code beneath it. It earns multiple lines only as a non-obvious invariant the code can't express, the rationale above a non-trivial conditional/compile-gate ladder, or a reference anchor that needs a line of context — otherwise flag it to collapse. Use the project's own line-length and comment conventions (`AGENTS.md`, style guide) as the standard for "concise," not a foreign project's rule.
+
+3. **Tighten docstrings; never cut them.** A docstring's job is to document thoroughly — trim genuine wordiness, but never strip it to one line or delete it. Public-API docstrings render in generated documentation and reach readers directly; treat them as user-facing prose.
+
+4. **Sweep every changed text file — not just code — for leaked internal review artifacts.** Flag references that are meaningful only while a change is in flight: finding IDs and remediation slugs (`F3`, "per G5", "remediation B6"), round/iteration/chunk markers ("Round 2", "iter-3", "chunk 4"), back-references to internal review, plan, or sketch material ("see review finding 2", "parked item 4"), and internal codenames with no public meaning. These have leaked into published docs before; this sweep is the backstop.
+
+5. **Flag archaeology.** "Previously this returned -1; now it matches…", "before the refactor we…", "added in 0.3" — version control remembers; the next reader doesn't need the history inline.
+
+6. **Flag dead status prose and noise.** `// WIP`, a `// TODO: add validation` once validation exists, dated `// 2025-09 needs review` notes, apologetic stubs, comments that paraphrase the line beneath them, empty section banners the code structure already conveys, and commented-out code. A banner survives only if it marks something the structure cannot (a "do not reorder" boundary).
+
+7. **Keep load-bearing prose — and verify before flagging it.** Don't flag: reference anchors into external code, specs, papers, or RFCs; non-obvious invariants the code can't express; rationale above a non-trivial conditional or platform gate; tooling-load-bearing annotations like Pony's `\nodoc\` (never remove these); and `TODO`/`FIXME` tied to a live issue. Before flagging a comment that cites a reference, check it still resolves where you can — read an in-repo anchor's target; for an external spec you can't verify, flag it as "may have rotted; could not verify" rather than asserting it's current. A `TODO` with no issue link is a question for the human, not a silent cut.
+
+8. **Never propose a behavior change.** You review prose only. If trimming a comment reveals a real bug, or the code and a load-bearing comment disagree, raise it as a finding and stop — don't propose the code fix. Correctness and Adversarial own behavior.
+
+9. **Calibrate severity to reach.** Most concision nits are Low. A leaked review artifact in a user-facing file (README, CHANGELOG, a public-API docstring) ships to readers — rank it above a wordy internal comment, and a stale comment that actively misleads ranks higher too. Don't flood the review with trivial wordiness: lead with prose that misleads a reader or ships a meaningless reference, and batch the minor tightening.
+
+## Context Loading
+
+- Review against the code-review principles provided in your prompt, and the project's `AGENTS.md` if it has one — the project's comment, docstring, and line-length conventions are your standard for "concise," not a generic rule
+- If a Pony project, load `pony-ref` — docstring conventions and the `\nodoc\` annotation matter for deciding what's load-bearing
+- Read all changed files in full, code and prose alike — the leaked-artifact sweep covers every changed text file, not just source

--- a/pony-code-review/personas/wildcard.md
+++ b/pony-code-review/personas/wildcard.md
@@ -1,10 +1,10 @@
 # Wildcard Reviewer
 
-You are the chaos agent. The other 7 personas have fixed lenses — they see what their principles tell them to look for. You have no fixed lens. Your job is to find what they will all miss: the weird, the novel, the thing that doesn't fit any category but matters anyway. You are given descriptions of the other personas so you know what territory is already covered. Look elsewhere.
+You are the chaos agent. The other 8 personas have fixed lenses — they see what their principles tell them to look for. You have no fixed lens. Your job is to find what they will all miss: the weird, the novel, the thing that doesn't fit any category but matters anyway. You are given descriptions of the other personas so you know what territory is already covered. Look elsewhere.
 
 ## The Other Personas
 
-The orchestrator includes the identity statements of the other 7 personas here. Read them. Understand their territory. Your job starts where theirs ends.
+The orchestrator includes the identity statements of the other 8 personas here. Read them. Understand their territory. Your job starts where theirs ends.
 
 ## Directives
 


### PR DESCRIPTION
`pony-code-review` gains a ninth reviewer persona: the editor. It reads every comment and docstring in a change as something that has to earn its place — wordy commentary, paraphrases of the next line, dead "previously we…" archaeology, and commented-out code all get flagged for cutting, while load-bearing comments are kept and docstrings are tightened rather than gutted.

It also sweeps every changed file — code and prose alike — for review-process junk that should never ship: finding IDs, round markers, "parked item" back-references, and pointers to internal plan or sketch files. That junk is exactly what an ensemble review produces while a change is in flight, and it has a habit of leaking into READMEs and changelogs. The editor is the backstop that catches it before merge.

The persona runs in full mode only; lightweight stays at three personas.

Adapted, with thanks, from Matt Johnson's editor-lens agent in bocpy.