### PR TITLE
Scope a fix to the defect, not to the report

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Ensemble documentation review — the prose counterpart to `pony-code-review`. L
 
 #### pony-vet-suspected-issues
 
-How to handle a problem you find outside the change you're working on — the bug you noticed in passing, or the out-of-scope finding a review turned up. Load it when you spot one, or when a PR is open and you have some to work through.
+How to handle a problem you notice while working on something else — the bug you spotted in passing, or a finding a review turned up. Load it when you spot one, or when a PR is open and you have some to work through.
 
-Instead of filing an issue on the spot, you capture it as a suspected issue and vet it after the PR is open: verify it, find its real scope, check for duplicates, and review the draft before filing — or discard it. `pony-code-review` and `pony-docs-review` route their out-of-scope findings here.
+First you decide whether it belongs to the change you're making — whether that change should have covered it. If it does, it is part of that change. If it doesn't, you capture it as a suspected issue instead of filing on the spot, and vet it after the PR is open: establish it's real, debug it for the cause and how far it reaches, check for duplicates, and review the draft before filing — or discard it. `pony-code-review` and `pony-docs-review` route findings outside the current change here.
 
 #### pony-test-design
 
@@ -156,7 +156,7 @@ Built on one idea — chance is not coverage, so a generator must bias toward wh
 
 Structured debugging protocol with checkpoints. Load it when debugging non-trivial issues — before forming any hypothesis about the cause.
 
-Provides an OODA-loop investigation process: characterize the failure, gather context, build a minimal reproduction, then iterate through hypothesis/experiment/observe cycles until all symptoms are explained. Especially valuable for Pony's subtle failure modes (capability violations, FFI issues, actor lifecycle problems, CI timeouts from undisposed resources).
+Provides an OODA-loop investigation process: characterize the failure, gather context, build a minimal reproduction, then iterate through hypothesis/experiment/observe cycles until all symptoms are explained. Then find every place the cause reaches, and only then where the fix belongs. Especially valuable for Pony's subtle failure modes (capability violations, FFI issues, actor lifecycle problems, CI timeouts from undisposed resources).
 
 ### Infrastructure
 
@@ -212,7 +212,7 @@ Prefer to pick individually? Add any of these instead:
 
 ### pony-vet-suspected-issues trigger
 
-> **Load `pony-vet-suspected-issues` for problems found outside the current change**: When you spot a bug or gap outside the change you're working on, or a review surfaces an out-of-scope finding, capture it as a suspected issue and vet it after the PR is open before filing — don't file on the spot. Load `pony-vet-suspected-issues`.
+> **Load `pony-vet-suspected-issues` for problems you notice while working on something else**: When you spot a bug or gap while working on something else, or a review surfaces a finding outside the current change, first decide whether it belongs to the change you're making — whether that change should have covered it. If it doesn't, capture it as a suspected issue and vet it after the PR is open before filing — don't file on the spot. Load `pony-vet-suspected-issues`.
 
 ### pony-test-design trigger
 

--- a/pony-code-review/SKILL.md
+++ b/pony-code-review/SKILL.md
@@ -90,6 +90,7 @@ When principles conflict, these values set the priority. We value the left side 
    - For Correctness, Adversarial, and Tests personas: the captured build output and test results from step 2.
    - The shared persona output format (below), including the evidence file path and instructions to write detailed evidence to that file and return a summary.
    - Instructions to run a reviewer loop before returning — the reviewer checks the persona's analysis for coherence, completeness, and evidence quality, not the underlying code a second time.
+   - Instructions that a change whose scope is wrong is itself a finding, in either direction. Too small: the persona sees something the change should have covered — another place the same cause reaches, another site where the shape being introduced belongs. Too large: it sees something in the change that no justification ties to the rest. Ask whether one reason accounts for everything the change does, and whether anything it should account for is missing. Don't withhold either kind because of where it sits in the diff. Everyone who looks at a change is responsible for whether its scope is right; no single step owns that.
    - Instructions that this is an ensemble agent — return findings to the orchestrator, don't take external actions.
 
    **For the Wildcard persona specifically:** include the identity statement (first paragraph) from each of the other 8 personas so the wildcard knows what territory is already covered.
@@ -112,7 +113,7 @@ The implementer categorizes each finding. Every finding must be categorized — 
 
 - **Fix**: The right action is obvious from the finding itself. Bugs, missing tests, stale docs, pattern violations, naming issues. Fix without waiting for the human.
 - **Park**: The finding needs the human's input. Design questions, principle tensions, ambiguous tradeoffs where reasonable people could disagree. Also park findings you disagree with — don't dismiss them. Parked items are listed in the PR for the human to weigh in on.
-- **Out of scope**: The finding is real but exists in code that isn't part of the current change. Don't fix it in this PR, and don't file an issue for it on the spot. Capture it as a suspected issue — carry the finding, its location, the evidence, and which persona(s) flagged it — and vet it after this PR is open before filing: confirm it still holds, find its real scope, check for duplicates, and review the draft. Load `pony-vet-suspected-issues` for the procedure. Filing straight from a review tends to produce issues that are wrong or miss the real scope; the persona's evidence is the starting point for vetting, not the finished issue.
+- **Out of scope**: What is left after you have asked whether the change should have covered it. Where the code sits is not the test. A change scoped too small has a diff that is too small, so "it isn't in the diff" rules out exactly the findings that would prove the change is too small. Ask first: does this finding mean the change is scoped too small? (`pony-vet-suspected-issues` has the test.) If it does, it is a Fix when covering it is the same kind of work the change already does, and a Park when covering it changes what the change is. Only what survives that question is out of scope. Don't fix it in this PR, and don't file an issue for it on the spot. Capture it as a suspected issue — carry the finding, its location, the evidence, and which persona(s) flagged it — and vet it after this PR is open before filing: confirm it still holds, find its real scope, check for duplicates, and review the draft. Load `pony-vet-suspected-issues` for the procedure. Filing straight from a review tends to produce issues that are wrong or miss the real scope; the persona's evidence is the starting point for vetting, not the finished issue.
 
 ### Re-review After Fixes
 
@@ -186,6 +187,7 @@ Pick whichever is most relevant to the change. If multiple conditions apply, pic
    - The captured build output and test results from step 2 — always provided to Correctness and Adversarial. Also provided to Tests when it is the context-dependent persona.
    - The shared persona output format (below), including the evidence file path and instructions to write detailed evidence to that file and return a summary.
    - Instructions to run a reviewer loop before returning — the reviewer checks the persona's analysis for coherence, completeness, and evidence quality, not the underlying code a second time.
+   - Instructions that a change whose scope is wrong is itself a finding, in either direction. Too small: the persona sees something the change should have covered — another place the same cause reaches, another site where the shape being introduced belongs. Too large: it sees something in the change that no justification ties to the rest. Ask whether one reason accounts for everything the change does, and whether anything it should account for is missing. Don't withhold either kind because of where it sits in the diff. Everyone who looks at a change is responsible for whether its scope is right; no single step owns that.
    - Instructions that this is an ensemble agent — return findings to the orchestrator, don't take external actions.
 
    When the review target is a fix, the Adversarial persona's prompt still includes the fix-specific focus from the ensemble protocol: construct a concrete scenario where the bug still occurs despite the fix.
@@ -206,7 +208,7 @@ Same categories as full mode:
 
 - **Fix**: Obvious action from the finding itself. Fix without waiting.
 - **Park**: Needs the human's input. Listed in the PR.
-- **Out of scope**: Real but in code outside this change. Capture it as a suspected issue and vet it after the PR before filing — load `pony-vet-suspected-issues`; don't file on the spot.
+- **Out of scope**: What is left after asking whether the change should have covered it — not simply "in code outside this change." If the finding shows the change is scoped too small, it is a Fix when covering it is the same kind of work the change already does, and a Park when covering it changes what the change is. Only what survives becomes a suspected issue: capture it and vet it after the PR before filing — load `pony-vet-suspected-issues`; don't file on the spot.
 
 No re-review loop. Fix the findings and proceed to opening the PR.
 
@@ -222,10 +224,11 @@ The synthesizer should pay special attention to:
 - **Test gaps matching other findings**: When the Tests persona identifies coverage gaps that align with issues found by Adversarial or Correctness, those are the highest-priority test additions.
 - **Principle violations others missed**: Findings from the Principles persona that no other persona noticed represent systematic blind spots.
 - **Cross-persona corroboration**: When multiple personas independently flag the same issue from different angles, that's high confidence. Call it out.
+- **Scope findings that point different ways**: When several personas each say the change should have covered something different, that is usually one signal rather than many — the change's boundary is drawn in the wrong place. Consolidate them into a single question about where that boundary belongs, weighed against "it is easier to give than take away." Passing along N separate widenings is how a focused change sprawls.
 - **Editor findings**: Most are Low — concision and tidiness. But a leaked internal review artifact (finding ID, round marker, sketch/plan backref) in a published or user-facing file, or a stale comment that actively misleads, is a real defect — don't downgrade it as "just style."
 - **Wildcard findings**: The wildcard persona deliberately looks for things the other personas miss. Its findings may be unconventional — evaluate them on merit, not on whether they fit a category. If a wildcard finding aligns with a faint signal from another persona, that's strong evidence both caught the same thing from different angles.
 - **Convergence failures** (re-reviews only): Check the review history for signs that an area isn't converging — recurring findings in the same location, fixes that add complexity instead of removing it, different symptoms of the same structural mismatch across rounds. When detected, escalate a specific structural question (see "Convergence Failure Detection" in the iterative workflow section). This is always a parked item.
-- **Pre-existing issues**: Findings about problems in code outside the current change are still findings — never silently discard them. Flag them clearly as pre-existing so the implementer can triage them as "out of scope" and capture them as suspected issues to vet after the PR. A review that discovers a real problem and then drops it because "it's not part of this PR" has wasted the discovery.
+- **Pre-existing issues**: Findings about problems in code outside the current change are still findings — never silently discard them. Flag them clearly as pre-existing so the implementer can triage them, starting with whether the change should have covered them. A review that discovers a real problem and then drops it because "it's not part of this PR" has wasted the discovery.
 - **When digging deeper**: Work from the summaries by default. Read the evidence files when a finding needs more context — when severities conflict, when a finding's summary is ambiguous, or when you need to verify the evidence supports the claim.
 
 ## Synthesis Focus: Lightweight Mode
@@ -237,7 +240,7 @@ The synthesizer should pay special attention to:
 - **Cross-persona corroboration**: When multiple personas independently flag the same issue from different angles, that's high confidence.
 - **Test gaps matching other findings**: When Tests is the context-dependent persona and identifies coverage gaps that align with issues found by Adversarial or Correctness, those are the highest-priority test additions.
 - **Editor findings**: Same as full mode — most are Low (concision, tidiness), but a leaked internal review artifact or a stale comment that actively misleads in a published or user-facing file is a real defect, not just style.
-- **Pre-existing issues**: Same as full mode — never silently discard them. Flag as pre-existing for "out of scope" triage.
+- **Pre-existing issues**: Same as full mode — never silently discard them. Flag as pre-existing for triage; the implementer asks whether the change should have covered them before concluding out-of-scope.
 - **Finding density signal**: If the 4 personas collectively produce more findings than expected for the change size, note this explicitly. A high density of findings on a small change suggests the change is more complex than it appeared and may warrant full mode. This is the synthesizer's primary escalation signal.
 - **When digging deeper**: Same as full mode — summaries by default, evidence files when needed.
 

--- a/pony-debug/SKILL.md
+++ b/pony-debug/SKILL.md
@@ -14,9 +14,13 @@ Don't assert a cause. State hypotheses explicitly. Prove the execution path with
 
 A hypothesis is not knowledge. If you can test it, test it. This protocol makes that concrete for debugging sessions.
 
+Start by vetting the claim — a filed issue, or a problem you noticed yourself. Do not assume the problem exists, that any purported cause is true, or that its scope is properly defined.
+
 ## When to use the full protocol
 
 This protocol is for non-trivial debugging — cases where you don't know the cause, or where your first guess could be wrong. If the cause is immediately obvious and verifiable in one step (a typo, a missing import), just fix it.
+
+When the work started from a bug report and you plan the fix before writing it, checkpoints 1 through 6 come first. A plan built from the report has already set the scope at the reported symptom, and every check after that argues against a plan that is already settled.
 
 ## Protocol
 
@@ -62,14 +66,62 @@ Then loop. Each iteration should narrow the space — ruling out possibilities, 
 
 **If stuck after 2-3 iterations without progress**: You are likely anchored to a bad hypothesis. Spawn a fresh-eyes subagent with the original problem, what you've tried, and your current hypothesis. The subagent's job is to verify your assumptions, generate alternative hypotheses, and report back. Act on its findings — don't dismiss them to defend your original theory.
 
-**Exit condition**: You can explain all observed symptoms and have evidence supporting each link in the causal chain. Only then proceed to the fix.
+**Exit condition**: You can explain all observed symptoms and have evidence supporting each link in the causal chain. Only then proceed to checkpoint 5.
 
-### Checkpoint 5: Fix and verify
+### Checkpoint 5: Find where the cause reaches
 
-Fix the root cause, not the symptom. Explain why this addresses the root cause. A sleep, a retry, or a "just check again" that masks the problem is not a fix. Run the reproduction to confirm.
+You know why the bug happens. Before you decide what to change, find where else that cause reaches. You cannot pick where to fix until you know what the fix has to cover.
 
-**Artifact**: The fix, the rationale for why it addresses the root cause, and evidence it resolves the issue.
+Bound the search by the mechanism checkpoint 4 gave you — the function, the field, the invariant that fails. That is what tells you when you are done, and it is why this is a directed search rather than a walk through the codebase.
+
+Start where the bug was reported, and follow the cause outward. Often it simply reaches further than one place: the same bad value arriving at three call sites when only one of them got reported.
+
+Sometimes it is worse than that. Two pieces of code are supposed to behave the same way, and nothing makes them. The difference between them is the defect, and the bugs it produces need not resemble each other at all — a crash in one, a hang in the other, a feature quietly absent from a third. What matters is that one thing produced them all. That divergence will keep producing bugs until you remove it.
+
+When that is what you have, the second bug is not a second issue to file. It is one defect showing up twice — so long as the two really are supposed to behave the same. When they are not, you have two defects, and the test below tells you which case you are in.
+
+Go and look. You cannot find those places from what you already know.
+
+**Three signs a divergence has been papered over instead of removed.**
+
+The first is in the fix you were about to write. It adds a field or a flag to one copy of something so that copy matches the other. Making two things agree by hand admits that nothing makes them agree.
+
+The second is already in the code: a comment saying two things must change together. Take it seriously. A comment pairing two things that sit near each other — same type, same file, a few lines apart — is not documenting a coupling; `pony-comments` is explicit that a pairing with both ends in one file is not one. So go and look at what it is holding together. Often it is a defect somebody wrote down instead of removing: a value stored in a field where it should have been passed, two branches that should have been one. Writing it down is what stopped it looking like a bug. Sometimes it is a real invariant the code cannot express, and then it stays. You will not know which until you look. If what you find is the cause of the bug you came for, removing it is the fix, and checkpoint 6 is where you decide the place. If it is a tidy-up you happened to notice, restructuring it is a decision to raise, not one to fold into a bug fix.
+
+The third is in the documentation. When one of two paths that should act alike is missing something, and the gap got written into the docs, the absence has been recorded as if it were a design choice.
+
+**When it really is two defects.** The test is not whether the two places share code. It is whether they are supposed to behave the same. Two read loops that must respond identically to the same events are one defect, however little code they share. A missing check in a parser and a missing check in an unrelated request handler are two, however alike they look — fix the one you came for and record the other as a suspected issue (`pony-vet-suspected-issues`). Two defects is the answer that costs you less work right now, so be careful reaching for it. You have to be able to say why the two are *not* supposed to behave the same. If you can't, treat them as one defect.
+
+Note what you saw anyway. The same mistake made independently twice is the best evidence you will get that the code permits a mistake it should make impossible. That is a design finding, worth more than either bug on its own. Raise it; don't quietly fix it.
+
+That advice is for two defects. One defect in two places doesn't get raised and left alone — checkpoint 6 decides where it gets fixed.
+
+**Artifact**: What you searched — the places the bad value can reach, and the code that ought to behave like the code the bug was reported in. How you found them, and what the cause does at each. Every place it reaches, the reported one among them. "Only the reported site" is a real answer, and it still has to name the places you ruled out.
+
+### Checkpoint 6: Find where the fix belongs
+
+Now pick the place to change. It has to cover every place checkpoint 5 found.
+
+Name it. Ask whether any of those bugs could still happen by a route that change does not cover. If one could, that was the wrong place — either something upstream is still producing the bad value and your fix catches it late, or the same bad value reaches call sites your change does not touch. Move and ask again.
+
+Sometimes no existing place covers everything. Two pieces of code that must agree, with nothing making them agree, have no shared place to fix, and that absence is the defect. Making them agree by hand, in each of them, is not the fix. Build the thing that makes them agree, and fix it there.
+
+That is a larger change than the report asked for. Say so — in the plan, in the pull request, wherever the people who have to live with it will read it. Building it quietly is how a bug fix becomes a rewrite nobody agreed to.
+
+If the cause reaches places you are not going to fix, that is a decision to raise, not a line to write here. If it cannot be fixed cleanly at any place you are able to change, say so and stop. Don't write the special case.
+
+**Artifact**: The place you will change, and why nothing checkpoint 5 found still breaks once you have changed it. If you stopped instead, that is the artifact: the places you considered, why none of them can hold a clean fix, and what would have to change for one to exist.
+
+### Checkpoint 7: Fix and verify
+
+Fix the cause, in the place checkpoint 6 identified. Explain why this addresses the cause. A sleep, a retry, or a "just check again" that masks the problem is not a fix. Run the reproduction to confirm. For the other places checkpoint 5 found, build a check for each — and where you can't build one, say so rather than assume.
+
+Read the fix you just wrote. Can you say why that code is there without mentioning the bug report? "The reader never returns an empty list" needs no report to make sense. "We check for an empty list here, because empty configs crashed" cannot be explained without one — the code is shaped like the report instead of like the program. If you need the report to explain the fix, you fixed the report. Go back to checkpoint 6.
+
+**Artifact**: The fix, the rationale for why it addresses the cause, and evidence it resolves the issue.
 
 ## Honest use
 
 The artifacts should reflect actual investigation, not be written retroactively after you've already decided on a cause. If you find yourself writing the characterization after you've already started coding a fix, you skipped the protocol — back up.
+
+Checkpoint 5 is where this matters most. "I looked and found nothing" and "I did not look" produce the same sentence. Only one of them is true, and only you know which.

--- a/pony-docs-review/SKILL.md
+++ b/pony-docs-review/SKILL.md
@@ -70,6 +70,7 @@ The pony-synthesize skill's output format is not a natural fit for documentation
    - Relevant gathered context from step 2, distributed to the personas that consume it (e.g. source code for Accuracy; related docs or style guides for Consistency or Principles when they run).
    - The shared persona output format (below), including the evidence file path and instructions to write detailed evidence to that file and return a summary.
    - Instructions to run a reviewer loop before returning — the reviewer checks the persona's analysis for coherence, completeness, and evidence quality, not the documentation a second time.
+   - Instructions that a change whose scope is wrong is itself a finding, in either direction. Too small: the persona sees something the change should have covered — another page the same problem reaches, another place the convention being introduced belongs. Too large: it sees something in the change that no justification ties to the rest. Ask whether one reason accounts for everything the change does, and whether anything it should account for is missing. Don't withhold either kind because of where it sits in the diff. Everyone who looks at a change is responsible for whether its scope is right; no single step owns that.
    - Instructions that this is an ensemble agent — return findings to the orchestrator, don't take external actions.
 
    **For the Wildcard persona specifically:** include the identity statement (first paragraph) from each of the other 7 personas so the wildcard knows what territory is already covered.
@@ -92,7 +93,7 @@ The implementer categorizes each finding. Every finding must be categorized — 
 
 - **Fix**: The right action is obvious from the finding itself. Factual errors, broken examples, missing steps, stale cross-references, terminology inconsistencies. Fix without waiting.
 - **Park**: The finding needs the maintainer's input. Tone questions, scope decisions, audience disagreements, ambiguous tradeoffs where reasonable people could disagree. Also park findings you disagree with — don't dismiss them. Parked items are listed in the PR for the maintainer to weigh in on.
-- **Out of scope**: The finding is real but exists in documentation that isn't part of the current change. Don't fix it in this PR, and don't file an issue for it on the spot. Capture it as a suspected issue — carry the finding, its location, the evidence, and which persona(s) flagged it — and vet it after this PR is open before filing: confirm it still holds, find its real scope, check for duplicates, and review the draft. Load `pony-vet-suspected-issues` for the procedure. Filing straight from a review tends to produce issues that are wrong or miss the real scope; the persona's evidence is the starting point for vetting, not the finished issue.
+- **Out of scope**: What is left after you have asked whether the change should have covered it. Where the documentation sits is not the test. A change scoped too small has a diff that is too small, so "it isn't in the diff" rules out exactly the findings that would prove the change is too small. Ask first: does this finding mean the change is scoped too small? (`pony-vet-suspected-issues` has the test.) If it does, it is a Fix when covering it is the same kind of work the change already does, and a Park when covering it changes what the change is. Only what survives that question is out of scope. Don't fix it in this PR, and don't file an issue for it on the spot. Capture it as a suspected issue — carry the finding, its location, the evidence, and which persona(s) flagged it — and vet it after this PR is open before filing: confirm it still holds, find its real scope, check for duplicates, and review the draft. Load `pony-vet-suspected-issues` for the procedure. Filing straight from a review tends to produce issues that are wrong or miss the real scope; the persona's evidence is the starting point for vetting, not the finished issue.
 
 ### Re-review After Fixes
 
@@ -163,6 +164,7 @@ Pick whichever is most relevant to the change. If multiple conditions apply, pic
    - Relevant gathered context from step 2, distributed to the personas that consume it (e.g. source code for Accuracy; related docs or style guides for Consistency or Principles when they run).
    - The shared persona output format (below), including the evidence file path and instructions to write detailed evidence to that file and return a summary.
    - Instructions to run a reviewer loop before returning — the reviewer checks the persona's analysis for coherence, completeness, and evidence quality, not the documentation a second time.
+   - Instructions that a change whose scope is wrong is itself a finding, in either direction. Too small: the persona sees something the change should have covered — another page the same problem reaches, another place the convention being introduced belongs. Too large: it sees something in the change that no justification ties to the rest. Ask whether one reason accounts for everything the change does, and whether anything it should account for is missing. Don't withhold either kind because of where it sits in the diff. Everyone who looks at a change is responsible for whether its scope is right; no single step owns that.
    - Instructions that this is an ensemble agent — return findings to the orchestrator, don't take external actions.
 
    When the review target is a fix, the Accuracy persona's prompt includes the fix-specific focus: verify that the corrected information is actually correct and that the fix doesn't introduce new inaccuracies.
@@ -183,7 +185,7 @@ Same categories as full mode:
 
 - **Fix**: Obvious action from the finding itself. Fix without waiting.
 - **Park**: Needs the human's input. Listed in the PR.
-- **Out of scope**: Real but in documentation outside this change. Capture it as a suspected issue and vet it after the PR before filing — load `pony-vet-suspected-issues`; don't file on the spot.
+- **Out of scope**: What is left after asking whether the change should have covered it — not simply "in documentation outside this change." If the finding shows the change is scoped too small, it is a Fix when covering it is the same kind of work the change already does, and a Park when covering it changes what the change is. Only what survives becomes a suspected issue: capture it and vet it after the PR before filing — load `pony-vet-suspected-issues`; don't file on the spot.
 
 No re-review loop. Fix the findings and proceed to opening the PR.
 
@@ -198,9 +200,10 @@ The synthesizer should pay special attention to:
 - **Completeness + Reader Experience alignment**: When both flag the same gap from different angles (Completeness: "step 3 is missing"; Reader Experience: "a reader would get stuck here"), that's the highest-priority addition.
 - **Clarity clusters**: Multiple clarity findings in the same section suggest the section needs restructuring, not sentence-level fixes. Escalate to a structural observation.
 - **Cross-persona corroboration**: When multiple personas independently flag the same issue from different angles, that's high confidence. Call it out.
+- **Scope findings that point different ways**: When several personas each say the change should have covered something different, that is usually one signal rather than many — the change's boundary is drawn in the wrong place. Consolidate them into a single question about where that boundary belongs, weighed against "it is easier to give than take away." Passing along N separate widenings is how a focused change sprawls.
 - **Wildcard findings**: The wildcard persona deliberately looks for things the other personas miss. Its findings may be unconventional — evaluate them on merit, not on whether they fit a category. If a wildcard finding aligns with a faint signal from another persona, that's strong evidence both caught the same thing from different angles.
 - **Convergence failures** (re-reviews only): Check the review history for signs that an area isn't converging — recurring findings in the same section, fixes that add complexity instead of clarifying, different symptoms of the same structural issue across rounds. When detected, escalate a specific structural question (see "Convergence Failure Detection" in the iterative workflow section). This is always a parked item.
-- **Pre-existing issues**: Findings about problems in documentation outside the current change are still findings — never silently discard them. Flag them clearly as pre-existing so the implementer can triage them as "out of scope" and capture them as suspected issues to vet after the PR. A review that discovers a real problem and then drops it because "it's not part of this PR" has wasted the discovery.
+- **Pre-existing issues**: Findings about problems in documentation outside the current change are still findings — never silently discard them. Flag them clearly as pre-existing so the implementer can triage them, starting with whether the change should have covered them. A review that discovers a real problem and then drops it because "it's not part of this PR" has wasted the discovery.
 - **When digging deeper**: Work from the summaries by default. Read the evidence files when a finding needs more context — when severities conflict, when a finding's summary is ambiguous, or when you need to verify the evidence supports the claim.
 
 ## Synthesis Focus: Lightweight Mode
@@ -211,7 +214,7 @@ The synthesizer should pay special attention to:
 - **Accuracy findings the completeness reviewer missed**: These are high-value — the content was there but wrong.
 - **Cross-persona corroboration**: When multiple personas independently flag the same issue from different angles, that's high confidence.
 - **Context-dependent persona alignment**: When the context-dependent persona's findings align with Accuracy or Completeness findings, those are the highest-priority items.
-- **Pre-existing issues**: Same as full mode — never silently discard them. Flag as pre-existing for "out of scope" triage.
+- **Pre-existing issues**: Same as full mode — never silently discard them. Flag as pre-existing for triage; the implementer asks whether the change should have covered them before concluding out-of-scope.
 - **Finding density signal**: If the 3 personas collectively produce more findings than expected for the change size, note this explicitly. A high density of findings on a small change suggests the change is more complex than it appeared and may warrant full mode. This is the synthesizer's primary escalation signal.
 - **When digging deeper**: Same as full mode — summaries by default, evidence files when needed.
 

--- a/pony-skills/SKILL.md
+++ b/pony-skills/SKILL.md
@@ -15,7 +15,7 @@ When one of these applies, load the named skill.
 | Designing APIs, types, features, or system boundaries (not just implementing an existing design) | `pony-software-design` |
 | Reviewing code, or before opening a PR | `pony-code-review` |
 | Reviewing a documentation-only change | `pony-docs-review` |
-| Handling a problem found outside the current change — capture it, then vet before filing an issue | `pony-vet-suspected-issues` |
+| A problem you notice while working on something else — decide whether it belongs in your change, and if not, capture it and vet it before filing an issue | `pony-vet-suspected-issues` |
 | Writing tests, or assessing test quality | `pony-test-design` |
 | Writing property-based or generative tests | `pony-pbt-patterns` |
 | Before forming a hypothesis about a non-trivial bug | `pony-debug` |

--- a/pony-vet-suspected-issues/SKILL.md
+++ b/pony-vet-suspected-issues/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: pony-vet-suspected-issues
-description: How to handle a problem you spot while working on something else — capture it as a suspected issue instead of filing on the spot, then after the current PR is open, vet each one (verify, scope, review) and file a correct issue or discard it. Load when you find an incidental, out-of-scope problem mid-task, when a code or docs review surfaces an out-of-scope finding, or when the PR is open and you have suspected issues to work through.
+description: How to handle a problem you spot while working on something else — decide whether it means the change you are making is scoped too small, and if it doesn't, capture it as a suspected issue instead of filing on the spot, then after the current PR is open, vet each one (verify, scope, review) and file a correct issue or discard it. Load when you find an incidental problem mid-task, when a code or docs review surfaces a finding outside the current change, or when the PR is open and you have suspected issues to work through.
 disable-model-invocation: false
 ---
 
 # Vet Suspected Issues
 
-When you spot a problem in code or documentation that is outside the change you are working on, do not file an issue for it on the spot. Write it down as a suspected issue and keep going. After the current PR is open, vet each one — verify it, scope it, review it — and only then file an issue, or discard it with a reason.
+When you spot a problem in code or documentation while working on something else, first decide whether it belongs to the change you are making — the capture test below. If it does not, do not file an issue for it on the spot. Write it down as a suspected issue and keep going. After the current PR is open, vet each one — verify it, scope it, review it — and only then file an issue, or discard it with a reason.
 
 The reason for the deferral: issues filed on the spot are often wrong or incomplete. You file them from a single observation while loaded on the work at hand, without confirming the problem holds, finding its real scope, searching for duplicates, or reviewing the issue itself. Moving the work to a phase with full attention and real verification is what makes the issue correct.
 
@@ -14,8 +14,8 @@ The reason for the deferral: issues filed on the spot are often wrong or incompl
 
 Two sources:
 
-- **You notice something while working** — an unrelated bug, a stale comment, a gap — in code or docs that is not part of your change.
-- **A review surfaces an out-of-scope finding** — `pony-code-review` and `pony-docs-review` route findings that are real but live outside the current change here, instead of filing them mid-review. These arrive with the persona's evidence and which persona flagged it. That evidence is the starting point for vetting, not a finished issue.
+- **You notice something while working** — a bug, a stale comment, a gap — in code or docs that the capture test below places outside your change.
+- **A review surfaces a finding outside the current change** — `pony-code-review` and `pony-docs-review` route findings that are real but live outside the current change here, instead of filing them mid-review. These arrive with the persona's evidence and which persona flagged it. That evidence is the starting point for vetting, not a finished issue.
 
 ## Suspected issues are not parked items
 
@@ -23,27 +23,54 @@ Keep the two apart. A **parked item** is a decision that needs the human's input
 
 ## Capture (while working)
 
-When you notice an out-of-scope problem, do not investigate it and do not file it. Add it to a suspected-issue list and keep moving. Each entry records enough to vet it later without rediscovering it:
+When you notice a problem, one question decides what happens to it — the capture test. **Does it mean the change you are making is scoped too small?**
+
+Not whether it sits nearby. Not whether the ticket mentioned it. Whether the work you are doing should have covered it.
+
+When you are fixing a bug, the question takes a sharp form: could one cause produce both this and the bug you were sent to fix? If it could, your fix is scoped to a symptom.
+
+When you are adding a feature or reshaping code, the same question takes another form: would leaving this alone leave the thing you are building wrong or half-done? Not merely leave value on the table somewhere else — wrong, here, for what you set out to do. If so, your change is scoped to one instance of an idea that has several.
+
+- **You cannot yet say what your own change is responsible for** → you cannot answer this about anything, so settle that first. Whatever the work is, you cannot say what belongs in it until you can say what it is for. When the work is a bug, that means you have not found the cause; go find it (load `pony-debug`). When it is a feature, its shape hasn't settled; go settle it (load `pony-software-design`). Write down what you found while you go, so it doesn't get lost. The uncertainty is never about the thing you found.
+- **You cannot state any way it belongs** → suspected issue. Write it down and keep moving. Most of the time you cannot even begin the sentence — a stale comment three files away has nothing to do with what you are building, and seeing that costs nothing.
+- **You can state a way it belongs** → look. If it does belong, it is part of the current change, not a suspected issue — fold it in. If it turns out not to, it goes on the list like anything else.
+
+Set the bar low. A wrong "this might belong" costs you a look. A wrong "this doesn't belong" costs you a change scoped to whatever somebody happened to notice, and nothing will tell you it happened. Nobody wrongly dismisses the stale comment. The wrong dismissals happen where a connection is plausible and passing on it is convenient.
+
+**Looking is not expanding.** Following the hunch commits you to nothing but finding out. If it does turn out to belong, it goes in the change. What stays a separate decision is anything *further* the looking turned up — the cleanup next door, the refactor you can now see. Keep the two apart: if looking meant committing to all of that, you would stop looking.
+
+Each entry on the list records enough to vet it later without rediscovering it:
 
 - What you saw, and where (`file:line`).
 - What you were doing when you noticed it.
 - Your initial hypothesis — marked as a hypothesis, not a conclusion.
+- Why you think it is separate from the work at hand — one sentence.
+
+That last line is cheap to write now and hard to reconstruct later. It is also the sentence that reads as plainly wrong once a shared cause turns up, which is what it is for.
 
 Capture bar: a concrete problem you can point at. A vague "this could be nicer" does not go on the list.
 
 Keep the list with the working session, alongside whatever you are already tracking for the current change. When the PR opens, surface the open suspected issues so the vetting phase works from them and a long session doesn't lose them.
 
+## Re-read the list once your change comes into focus
+
+The moment you can say what your change is responsible for — for a bug, when you know why it happens; for a feature, when its shape settles — and before you write any code, read the suspected-issue list once and ask which entries it now covers.
+
+This catches what capture cannot. Two symptoms of one cause often look nothing alike. A crash on an empty config file and a logger that misbehaves at startup share no description, so nothing at capture time connects them. Once you are holding the initialization-order bug, both are obvious. A feature does the same thing: the shape you settle on turns out to cover something you had already written off.
+
+It costs one pass over a list you already wrote, at the one moment when the answer is free. Anything your change now covers stops being a suspected issue and becomes part of the work.
+
 ## Vet (after the current PR is open)
 
-Run this after the current PR is open, as its own closing phase — not while the main work is in flight. It is not a side quest. (If a suspected issue turns out to be part of the current change after all, it stops being one and folds into that work instead.)
+Run this after the current PR is open, as its own closing phase — not while the main work is in flight. It is not a side quest. (If a suspected issue turns out to be part of the current change after all, it stops being one and folds into that work instead — though normally you caught that when you found the cause.)
 
 Lock down each suspected issue. Default to the lightweight path; escalate when one is bigger than it looked.
 
-1. **Verify it's real.** Spawn a fresh-context agent. Give it the suspected issue — the observation, the location, your hypothesis — and have it read the actual code and judge whether the problem is real, from evidence rather than argument. For a behavioral bug, verifying means reproducing it (load `pony-debug`). If the suspected issue came from a review persona, you already have its evidence: confirm it still holds and build on it, rather than re-deriving the finding from scratch. Outcomes:
-   - **Confirmed** — continue.
+1. **Establish that it is real.** Spawn a fresh-context agent. Give it the suspected issue — the observation, the location, your hypothesis — and have it read the actual code and judge from evidence rather than argument. For a behavioral bug that means reproducing it: load `pony-debug` and work the protocol until the failure happens in front of you. If the suspected issue came from a review persona, you already have its evidence: confirm it still holds and build on it, rather than re-deriving the finding from scratch. Outcomes:
+   - **Confirmed** — it is real. Continue.
    - **Not a problem** — discard it and record why. This is a real outcome, not a failure. It is the wrong issue caught before it ships.
    - **Needs more information** — dig until you can confirm or discard.
-2. **Find the true scope and root cause.** One instance or a pattern? What is the actual extent? A premature issue describes one symptom; vetting finds the whole shape. This is what stops issues from missing points.
+2. **Debug it.** Carry on through `pony-debug`, as far as the fix, without writing one. That gives you the cause and every place it reaches. A premature issue describes one symptom; this is what finds the whole shape, and it is what stops issues from missing points.
 3. **Check for duplicates.** Search the existing issues so you do not file one that is already there.
 4. **Draft the issue.** Follow the project's issue conventions. Keep the body about the problem itself — the symptom, where it lives, the evidence, the scope — not about the review or how the issue came to be filed. Set whatever issue type or labels the project uses.
 5. **Review the draft.** A fresh-context reviewer checks that the claim holds, the scope is right, and nothing is missing. This is the direct fix for issues that miss points.
@@ -53,4 +80,4 @@ Lock down each suspected issue. Default to the lightweight path; escalate when o
 
 If vetting a suspected issue surfaces a question that is the human's to decide — a design call, an ambiguous tradeoff — it stops being a suspected issue and becomes a parked item for the human, rather than being forced into an issue.
 
-**Fast path:** a problem with nothing behavioral to verify — a typo, a stale comment — skips the reproduction in step 1. Give it a light check and file. Anything that claims a bug or a behavior takes the full path. "It's obviously fine to skip" is exactly the judgment that produces wrong issues.
+**Fast path:** a problem with nothing behavioral behind it — a typo, a stale comment — skips steps 1 and 2. Check that first: a comment recording a gap in behavior is a bug with a docstring on it, and takes the full path. When there is genuinely nothing behavioral, there is no failure to reproduce and no cause to find. Give it a light check and file. Anything that claims a bug or a behavior takes the full path. "It's obviously fine to skip" is exactly the judgment that produces wrong issues.


### PR DESCRIPTION
An agent handed a bug report fixed the thing the report named and stopped. Whatever else it noticed got called out of scope, because out of scope meant not in the diff — and a change scoped too small doesn't leave enough diff to show it was scoped wrong. The defect stayed, and the next bug it produced got its own patch.

In `pony-debug` you now find where the cause reaches before you pick the place to fix, because you cannot choose the place until you know what the fix has to cover. When two pieces of code are supposed to behave the same way and nothing makes them, the difference between them is the defect, not the bug you were handed.

You no longer settle what belongs in a change at a single step. In `pony-vet-suspected-issues`, capture turns on one question: does what you noticed mean your change is scoped too small? A shared cause when the work is a bug; when it's a feature, whether leaving the thing alone would leave what you're building half-done. In `pony-code-review` and `pony-docs-review`, out-of-scope no longer turns on where the code sits, and a reviewer who sees the change missing something it should have covered, or carrying something that doesn't belong, raises either as a finding.

The case behind all of it is ponylang/lori#315. A segfault, a muting bug, and a missing feature that got written into the docs as a design limitation, all from one cause: an SSL read loop and a plain read loop, maintained separately, with nothing forcing them to agree.
