### PR TITLE
Add pony-prose, the rulebook for writing prose plainly

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,28 @@ What's in the `references/` directory (read on demand for deeper questions):
 
 ### Project Conventions
 
+#### pony-prose
+
+How the words read in any prose that ships with the code — comments, docstrings, release notes, READMEs, commit messages. Load it before writing any of them. It is the layer under the form-specific skills: they say what belongs in each kind of prose, this says how to write it plainly.
+
+What's in the quick reference:
+
+- Write plainly, and stop there — no flourish pass for these forms
+- Say a fact the reader can check; cover the phrasing and confirm a claim remains
+- Never coin jargon; don't give non-person nouns intent or a job; keep antecedents clear
+- Don't inflate or invent; aim criticism at the problem, never the person
+
+#### pony-comments
+
+What earns a comment, what never belongs in one, and what to do when two distant things must change together. Load it before writing or changing a comment or docstring. Pairs with `pony-prose`, which covers how the words themselves read.
+
+What's in the quick reference:
+
+- Default to not writing a comment; a better name beats a comment that can go stale
+- Never write a fact with a shelf life (what CI runs, whether a test exists, a version)
+- Never narrate history, list callers, or leave dead status prose
+- The coupling decision: remove it, pin it, or comment both ends — in that order
+
 #### pony-examples-readme
 
 Conventions for writing `examples/README.md` files in ponylang projects. Load it when adding, updating, or reorganizing examples.
@@ -128,7 +150,7 @@ Has full (8-persona) and lightweight (5-persona) modes. Full mode runs design (3
 
 Ensemble code review with specialized reviewer personas. Load it when conducting a code review of a PR, branch, or local changes.
 
-Has full (9-persona, iterative re-review) and lightweight (4-persona, single pass) modes. Personas cover correctness, security, performance, API design, test quality, adversarial scenarios, design principles, comment and docstring economy, and wildcard concerns.
+Has full (9-persona, iterative re-review) and lightweight (4-persona, single pass) modes. Personas cover correctness, security, performance, API design, test quality, adversarial scenarios, design principles, prose economy (comments, docstrings, release notes, READMEs), and wildcard concerns.
 
 #### pony-docs-review
 
@@ -185,6 +207,14 @@ Prefer to pick individually? Add any of these instead:
 ### pony-ref trigger
 
 > **Load `pony-ref` proactively when working on Pony code**: At the start of any conversation where the working directory is a Pony project (contains `corral.json` or `*.pony` files), load `pony-ref` before doing any work. Also load it mid-conversation when hitting capabilities, type system, runtime, or testing questions.
+
+### pony-prose trigger
+
+> **Load `pony-prose` before writing prose that ships with the code**: Before writing or changing a comment, docstring, release note, README, issue, PR description, or commit message, load `pony-prose` — the rulebook for writing it plainly.
+
+### pony-comments trigger
+
+> **Load `pony-comments` before writing a comment or docstring**: Before writing or changing any comment or docstring, load `pony-comments` — what earns a comment, what never belongs in one, and how to handle two distant things that must change together.
 
 ### pony-examples-readme trigger
 

--- a/pony-code-review/SKILL.md
+++ b/pony-code-review/SKILL.md
@@ -83,7 +83,7 @@ When principles conflict, these values set the priority. We value the left side 
 
 4. **Spawn 9 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. Each agent's prompt includes:
 
-   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `pony-comments`, `pony-test-design`, `pony-pbt-patterns`, `pony-ref`), read that skill's content and include it in the agent prompt. The Editor persona's rulebook is `pony-comments`; it must be injected in full or the persona has no standard to review against.
+   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `pony-prose`, `pony-comments`, `pony-test-design`, `pony-pbt-patterns`, `pony-ref`), read that skill's content and include it in the agent prompt. The Editor persona reviews every kind of prose in the diff, and its rulebooks must be injected in full or it has no standard to review against: `pony-prose` always, plus the form skill for each kind of prose the change touches — `pony-comments` for comments and docstrings in code, `pony-release-notes` for release notes and CHANGELOG entries, `pony-library-readme` or `pony-examples-readme` for READMEs.
    - The code-review principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project `AGENTS.md` if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
    - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
    - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
@@ -150,9 +150,9 @@ Lightweight mode runs 4 personas in a single pass with no iterative re-review. L
 |------|-------|
 | `correctness.md` | Logic, edge cases, completeness for valid inputs |
 | `adversarial.md` | Concrete break scenarios, backward from failure |
-| `editor.md` | Comment and docstring economy, leaked-artifact sweep |
+| `editor.md` | Prose economy — comments, docstrings, release notes, READMEs — and leaked-artifact sweep |
 
-Editor runs on every lightweight review: verbose or stale comments and leaked review artifacts creep into small changes as readily as big ones, and the persona calibrates its own severity — most concision nits are Low — so it won't flood a small review.
+Editor runs on every lightweight review: wordy or stale prose and leaked review artifacts creep into small changes as readily as big ones, and the persona calibrates its own severity — most economy nits are Low — so it won't flood a small review.
 
 **Context-dependent slot (pick 1):**
 
@@ -180,7 +180,7 @@ Pick whichever is most relevant to the change. If multiple conditions apply, pic
 
 4. **Spawn 4 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. Each agent's prompt includes:
 
-   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `pony-comments`, `pony-test-design`, `pony-pbt-patterns`, `pony-ref`), read that skill's content and include it in the agent prompt. The Editor persona's rulebook is `pony-comments`; it must be injected in full or the persona has no standard to review against.
+   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `pony-prose`, `pony-comments`, `pony-test-design`, `pony-pbt-patterns`, `pony-ref`), read that skill's content and include it in the agent prompt. The Editor persona reviews every kind of prose in the diff, and its rulebooks must be injected in full or it has no standard to review against: `pony-prose` always, plus the form skill for each kind of prose the change touches — `pony-comments` for comments and docstrings in code, `pony-release-notes` for release notes and CHANGELOG entries, `pony-library-readme` or `pony-examples-readme` for READMEs.
    - The code-review principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project `AGENTS.md` if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
    - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
    - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
@@ -225,7 +225,7 @@ The synthesizer should pay special attention to:
 - **Principle violations others missed**: Findings from the Principles persona that no other persona noticed represent systematic blind spots.
 - **Cross-persona corroboration**: When multiple personas independently flag the same issue from different angles, that's high confidence. Call it out.
 - **Scope findings that point different ways**: When several personas each say the change should have covered something different, that is usually one signal rather than many — the change's boundary is drawn in the wrong place. Consolidate them into a single question about where that boundary belongs, weighed against "it is easier to give than take away." Passing along N separate widenings is how a focused change sprawls.
-- **Editor findings**: Most are Low — concision and tidiness. But a leaked internal review artifact (finding ID, round marker, sketch/plan backref) in a published or user-facing file, or a stale comment that actively misleads, is a real defect — don't downgrade it as "just style."
+- **Editor findings**: Most are Low — economy and tidiness. But prose that misleads a reader is a real defect, not "just style": a leaked internal review artifact (finding ID, round marker, sketch/plan backref) in a published or user-facing file, a stale comment that contradicts the code, or a release note that describes the implementation instead of what the user sees. Don't downgrade those.
 - **Wildcard findings**: The wildcard persona deliberately looks for things the other personas miss. Its findings may be unconventional — evaluate them on merit, not on whether they fit a category. If a wildcard finding aligns with a faint signal from another persona, that's strong evidence both caught the same thing from different angles.
 - **Convergence failures** (re-reviews only): Check the review history for signs that an area isn't converging — recurring findings in the same location, fixes that add complexity instead of removing it, different symptoms of the same structural mismatch across rounds. When detected, escalate a specific structural question (see "Convergence Failure Detection" in the iterative workflow section). This is always a parked item.
 - **Pre-existing issues**: Findings about problems in code outside the current change are still findings — never silently discard them. Flag them clearly as pre-existing so the implementer can triage them, starting with whether the change should have covered them. A review that discovers a real problem and then drops it because "it's not part of this PR" has wasted the discovery.
@@ -239,7 +239,7 @@ The synthesizer should pay special attention to:
 - **Adversarial findings the correctness reviewer missed**: These are high-value — the correctness reviewer was looking forward from the code and didn't see the failure path.
 - **Cross-persona corroboration**: When multiple personas independently flag the same issue from different angles, that's high confidence.
 - **Test gaps matching other findings**: When Tests is the context-dependent persona and identifies coverage gaps that align with issues found by Adversarial or Correctness, those are the highest-priority test additions.
-- **Editor findings**: Same as full mode — most are Low (concision, tidiness), but a leaked internal review artifact or a stale comment that actively misleads in a published or user-facing file is a real defect, not just style.
+- **Editor findings**: Same as full mode — most are Low (economy, tidiness), but prose that misleads a reader is a real defect, not just style: a leaked internal review artifact, a stale comment that contradicts the code, or a release note that describes the implementation instead of what the user sees.
 - **Pre-existing issues**: Same as full mode — never silently discard them. Flag as pre-existing for triage; the implementer asks whether the change should have covered them before concluding out-of-scope.
 - **Finding density signal**: If the 4 personas collectively produce more findings than expected for the change size, note this explicitly. A high density of findings on a small change suggests the change is more complex than it appeared and may warrant full mode. This is the synthesizer's primary escalation signal.
 - **When digging deeper**: Same as full mode — summaries by default, evidence files when needed.
@@ -304,5 +304,5 @@ The persona documents are in `personas/`. Full mode uses all 9; lightweight uses
 | `performance.md` | Architectural bottlenecks, then local waste |
 | `tests.md` | Test quality, missing tests, counterfactual reasoning |
 | `principles.md` | Systematic principles audit with evidence |
-| `editor.md` | Comment and docstring economy, leaked-artifact sweep |
+| `editor.md` | Prose economy — comments, docstrings, release notes, READMEs — and leaked-artifact sweep |
 | `wildcard.md` | Chaos agent — finds what the others miss |

--- a/pony-code-review/personas/editor.md
+++ b/pony-code-review/personas/editor.md
@@ -1,12 +1,18 @@
 # Editor Reviewer
 
-You are the ruthless editor. You treat every comment in the changed code as a liability until proven otherwise: comments rot, mislead once they go stale, and bury the few that matter. Your default recommendation is to cut a comment unless a maintainer would write it again today, from scratch — but docstrings are the exception: you tighten them, never delete them. You don't author comments, you don't flag *missing* docs (Principles owns that), and you don't review behavior (Correctness and Adversarial own that).
+You are the ruthless editor. You review every kind of prose in the change — comments, docstrings, release notes, CHANGELOG entries, READMEs — for whether the words earn their place and read plainly. You treat every comment as a liability until proven otherwise: comments rot, mislead once they go stale, and bury the few that matter. Your default recommendation is to cut a comment unless a maintainer would write it again today, from scratch — but docstrings and the user-facing prose (release notes, READMEs) are the exception: you tighten them, never delete them. You don't author prose, you don't flag *missing* docs (Principles owns that), and you don't review behavior (Correctness and Adversarial own that).
 
-## Your rulebook
+## Your rulebooks
 
-`pony-comments` is provided in full in your prompt. It is the standard for what earns a comment, what never belongs in one, and what to do when two distant things must change together. Every finding you raise cites a rule in it. Don't re-derive those rules here and don't invent new ones — if a comment is fine by the rulebook, it is fine.
+Two kinds, both provided in full in your prompt.
 
-What follows is how to *review* against it.
+`pony-prose` is the standard for *how the words read* in any prose: plainly, saying a checkable fact, no coined jargon, no anthropomorphizing, clear antecedents. It applies to every kind of prose in the change.
+
+The form skills are the standard for *what belongs* in each kind. `pony-comments` — what earns a comment at all, what never belongs in one, and what to do when two distant things must change together. `pony-release-notes` — what a release note describes. `pony-library-readme` and `pony-examples-readme` — what a README holds. You get the ones that match the prose the change touches.
+
+Every finding you raise cites a rule in one of these. Don't re-derive those rules here and don't invent new ones — if the prose is fine by the rulebooks, it is fine.
+
+What follows is how to *review* against them.
 
 ## Core Principles
 
@@ -14,7 +20,7 @@ What follows is how to *review* against it.
 
 2. **Flag wordy multi-line inline comments for collapsing.** An inline comment (`//` or `/* */` inside a method body or above a statement) that sprawls across several lines drifts out of sync with the code beneath it. It earns multiple lines only as a non-obvious invariant the code can't express, the rationale above a non-trivial conditional/compile-gate ladder, or a reference anchor that needs a line of context — otherwise flag it to collapse. Use the project's own line-length and comment conventions (`AGENTS.md`, style guide) as the standard for "concise," not a foreign project's rule.
 
-3. **Tighten docstrings; never cut them.** Trim genuine wordiness, but never strip one to a line or delete it. Public-API docstrings render in generated documentation and reach readers directly; treat them as user-facing prose. When a docstring breaks a rulebook rule, rewrite to drop the offending part rather than deleting the docstring.
+3. **Tighten docstrings; never cut them.** Trim genuine wordiness, but never strip one to a line or delete it. Public-API docstrings render in generated documentation and reach readers directly; treat them as user-facing prose. The line for "wordy" is in `pony-comments`: a docstring gives a caller what they need to use the thing correctly and says nothing about how it works — so flag a docstring that explains the implementation or restates the signature, and rewrite to drop that part rather than deleting the docstring.
 
 4. **Sweep every changed text file — not just code — for leaked internal review artifacts.** Flag references that are meaningful only while a change is in flight: finding IDs and remediation slugs (`F3`, "per G5", "remediation B6"), round/iteration/chunk markers ("Round 2", "iter-3", "chunk 4"), back-references to internal review, plan, or sketch material ("see review finding 2", "parked item 4"), and internal codenames with no public meaning. These have leaked into published docs before; this sweep is the backstop. The rulebook doesn't cover these — they exist only because a review happened.
 
@@ -30,11 +36,14 @@ What follows is how to *review* against it.
 
 8. **Never propose a behavior change.** You review prose only. If trimming a comment reveals a real bug, or the code and a load-bearing comment disagree, raise it as a finding and stop — don't propose the code fix. Correctness and Adversarial own behavior.
 
-9. **Calibrate severity to reach.** Most concision nits are Low. A shelf-life claim that is already false, or a leaked review artifact in a user-facing file (README, CHANGELOG, a public-API docstring), misleads a reader — rank those higher. Don't flood the review with trivial wordiness: lead with prose that misleads, and batch the minor tightening.
+9. **Review release notes and READMEs against their own form skill.** These are prose too, and they reach users directly. A release note earns a finding when it describes the implementation instead of what the user sees, or names the dependency behind a fixed bug — `pony-release-notes` is the standard. A README earns one when it drifts from the structure its README skill defines. And `pony-prose` applies to both: the same plainness, the same "say a checkable fact," the same no-coined-jargon. "Default to cut" does not apply here — like docstrings, this is user-facing prose you tighten, not delete.
+
+10. **Calibrate severity to reach.** Most economy nits are Low. Prose that misleads a reader ranks higher: a shelf-life claim already false, a leaked review artifact in a user-facing file (README, CHANGELOG, a public-API docstring), a release note describing internals. Don't flood the review with trivial wordiness — lead with prose that misleads, and batch the minor tightening.
 
 ## Context Loading
 
-- `pony-comments` is your rulebook, provided in full — read it first
-- Review also against the code-review principles provided in your prompt, and the project's `AGENTS.md` if it has one — the project's comment, docstring, and line-length conventions are your standard for "concise," not a generic rule
+- `pony-prose` is your rulebook for how the words read, provided in full — read it first; it applies to every kind of prose in the change
+- The form skills are your rulebooks for what belongs in each kind, provided in full for whatever the change touches: `pony-comments` for comments and docstrings, `pony-release-notes` for release notes and CHANGELOG entries, `pony-library-readme` / `pony-examples-readme` for READMEs
+- Review also against the code-review principles provided in your prompt, and the project's `AGENTS.md` if it has one — the project's own comment, docstring, and line-length conventions are your standard for collapsing wordy inline comments, not a generic rule
 - If a Pony project, load `pony-ref` — docstring conventions and the `\nodoc\` annotation matter for deciding what's load-bearing
 - Read all changed files in full, code and prose alike — the leaked-artifact sweep covers every changed text file, not just source

--- a/pony-comments/SKILL.md
+++ b/pony-comments/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: false
 
 A comment is forever. The code around it moves, the tests move, the build moves, and the comment stays exactly as written with nothing to tell you it started lying. Comments have no tests. Write accordingly.
 
-This is the rulebook. The editor persona in `pony-code-review` checks changed code against it.
+Load `pony-prose` first: it is the rulebook for how the words read, in a comment or anywhere else. This skill is the rulebook for what earns a comment at all. The editor persona in `pony-code-review` checks changed prose against both.
 
 ## Default: don't
 
@@ -35,9 +35,9 @@ The information is still worth having. It belongs where the machinery is documen
 
 One word needs care. "Silently" is a fact about the program when it means the code produces a wrong value and raises nothing. It is a shelf-life claim when it means no test catches it. Only the first belongs in a comment.
 
-## Never coin jargon
+## A comment exists to explain
 
-A comment exists to explain. One that doesn't is worse than none — it costs the reader effort and returns nothing. Never name what the code does in shorthand you minted on the spot: invented compounds ("green-skip," "main miss"), pseudo-technical labels. The tell is that the term reads like real vocabulary — next to "garbage collection" it looks legitimate — but nobody can decode it, because it means something mundane. Write what happens in plain words. Established domain terms, and terms the project itself defines, are fine.
+One that doesn't is worse than none — it costs the reader effort and returns nothing. The plainness rules that keep a comment legible, including never coining jargon for what the code does, live in `pony-prose`; load it before writing one.
 
 ## Never narrate history
 
@@ -110,7 +110,9 @@ Whether the coupling *can* be tested is a real question and a separate one. If i
 
 ## Docstrings are different
 
-They are for the people using the thing, not the people maintaining it. Write them fully — "default: don't" does not apply. Every rule above about shelf life, jargon, and history still does.
+They are for the people using the thing, not the people maintaining it. Write them fully — "default: don't" does not apply. The rules above about shelf life and history still do, as do all of `pony-prose`'s.
+
+Full does not mean padded. A docstring gives a caller what they need to use the thing correctly: what it does, and the guarantees they can rely on. It says nothing about how it works, and it doesn't restate the signature.
 
 In Pony, `\nodoc\` on test declarations is load-bearing tooling, not prose. Never remove it.
 

--- a/pony-docs-review/personas/clarity.md
+++ b/pony-docs-review/personas/clarity.md
@@ -8,23 +8,23 @@ You evaluate whether the documentation communicates its content effectively to t
 
 2. **Flag ambiguous sentences.** A sentence is ambiguous when a reasonable reader could interpret it two ways. "The server handles requests after initialization" — does this mean "once initialization is complete" or "the server processes requests that arrive after it initializes"? If you have to re-read to decide, it's ambiguous.
 
-3. **Check antecedent clarity.** Every pronoun and demonstrative ("it," "this," "that," "these") should have an unambiguous referent. "Configure the server and the database. It should be restarted after changes" — which one?
+3. **Identify jargon without definition.** Technical terms are fine when the audience knows them. Technical terms without definition in content aimed at people who might not know them are barriers. The test: would the target audience know this term before reading this document? (This is a different rule from `pony-prose`'s "never coin jargon," which forbids *inventing* a term. Here the term is real and established — the reader just doesn't know it yet.)
 
-4. **Identify jargon without definition.** Technical terms are fine when the audience knows them. Technical terms without definition in content aimed at people who might not know them are barriers. The test: would the target audience know this term before reading this document?
+4. **Flag passive voice that hides the actor.** "The configuration file should be updated" — by whom? The user? The system? An automated process? Passive voice is fine when the actor is obvious or irrelevant. It's a problem when it leaves the reader unsure who should do something.
 
-5. **Flag passive voice that hides the actor.** "The configuration file should be updated" — by whom? The user? The system? An automated process? Passive voice is fine when the actor is obvious or irrelevant. It's a problem when it leaves the reader unsure who should do something.
+5. **Check sentence complexity.** Long sentences with multiple clauses, nested conditionals, or chains of prepositional phrases are hard to parse. If a sentence needs to be re-read to understand, it should be split or simplified.
 
-6. **Check sentence complexity.** Long sentences with multiple clauses, nested conditionals, or chains of prepositional phrases are hard to parse. If a sentence needs to be re-read to understand, it should be split or simplified.
+6. **Verify consistent terminology.** When the same concept is called different things in different places ("config file," "configuration," "settings file," "config"), readers waste effort figuring out whether these are the same thing. One concept, one term — everywhere in the document.
 
-7. **Verify consistent terminology.** When the same concept is called different things in different places ("config file," "configuration," "settings file," "config"), readers waste effort figuring out whether these are the same thing. One concept, one term — everywhere in the document.
+7. **Check that examples clarify rather than obscure.** An example should make the preceding explanation concrete. If the example introduces new complexity (unexplained options, edge cases, additional concepts) without addressing it, it confuses rather than clarifies.
 
-8. **Check that examples clarify rather than obscure.** An example should make the preceding explanation concrete. If the example introduces new complexity (unexplained options, edge cases, additional concepts) without addressing it, it confuses rather than clarifies.
+8. **Evaluate paragraph structure.** Each paragraph should have one main point. Paragraphs that cover multiple ideas force the reader to untangle them. The first sentence should signal what the paragraph is about.
 
-9. **Evaluate paragraph structure.** Each paragraph should have one main point. Paragraphs that cover multiple ideas force the reader to untangle them. The first sentence should signal what the paragraph is about.
+Unclear antecedents — every "it," "this," "that" needing an obvious referent — are covered by `pony-prose`, injected below; raise them as `pony-prose` findings rather than duplicating the rule here.
 
 ## Context Loading
 
-- Review against the documentation principles provided in your prompt, and the project's `AGENTS.md` if it has one
-- If the project has voice or style guidelines, load them — clarity should be evaluated within the project's established voice, not against a generic standard
+- `pony-prose` is your rulebook for prose that reads plainly — antecedents, coined jargon, anthropomorphizing, and the rest — provided in full; read it first and review against it. It replaces the generic "load the project's voice guidelines if it has any," which no project ships.
+- Review also against the documentation principles provided in your prompt, and the project's `AGENTS.md` if it has one
 - Read the full changed documentation, not just diffs — clarity depends on surrounding context and flow
 - Identify the target audience from the document's position in the doc set (tutorial vs. reference vs. guide)

--- a/pony-examples-readme/SKILL.md
+++ b/pony-examples-readme/SKILL.md
@@ -8,6 +8,8 @@ disable-model-invocation: false
 
 These conventions are derived from existing ponylang examples/README.md files (postgres, redis, lori, crdt, uri, web_link). Follow them when writing or updating an examples/README.md.
 
+Load `pony-prose` for how the prose reads. This skill says what an examples README holds; `pony-prose` says how to write it plainly.
+
 ## Structure
 
 1. **Title** — Always `# Examples`.

--- a/pony-library-readme/SKILL.md
+++ b/pony-library-readme/SKILL.md
@@ -8,6 +8,8 @@ disable-model-invocation: false
 
 These conventions are derived from existing ponylang library READMEs and should be followed when writing or updating a README.md for a Pony library project.
 
+Load `pony-prose` for how the prose reads. This skill says what a README holds; `pony-prose` says how to write it plainly.
+
 ## Required Sections (in order)
 
 Every Pony library README has these sections in this order:

--- a/pony-prose/SKILL.md
+++ b/pony-prose/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: pony-prose
+description: How the words go in a comment, docstring, release note, or README — write plainly, say the fact, and stop. Load before writing any prose that ships with the code. Language-agnostic.
+disable-model-invocation: false
+---
+
+# Prose
+
+The form tells you what to say. This tells you how to say it.
+
+A comment, a docstring, a release note, a CHANGELOG entry, a README, an issue body, a PR description, a commit message — each has a skill that says what belongs in it and what to leave out. This skill is the layer under all of them: how the words themselves read once you've decided what to write. Load it alongside the form's own skill.
+
+## Plain is where you stop
+
+Get the true thing down with no decoration, and that is the finished state. There is no later pass that adds flourish on top. A blog post earns its flourish; a docstring does not. For the forms this skill governs, plain is the finished state, not a step toward something more polished.
+
+Short, direct sentences. State each fact as plainly as you can. If a reader would have to reread a sentence to work out what it means, it is too clever or too packed; say the thing first, in plain words, then the mechanism.
+
+## Say the fact
+
+Every sentence has to carry something a reader could check or act on: what changed, what broke, what it does now, the actual mechanism named plainly.
+
+The check is mechanical. Cover the decorative part of a sentence and read what is left. If a concrete claim remains, keep it and cut the decoration. If nothing is left, the sentence is empty — it sounds like something and says nothing — so write the real fact in or cut the sentence. "Small buffers were reallocating when they had no business doing so" — "no business" is an opinion, not a fact; say the change: building a small buffer no longer does an extra reallocation.
+
+## Don't reach for phrasing instead of the fact
+
+Flourish that stands in for content is the most common failure and the hardest to catch, because it reads well. It takes six forms:
+
+- **Flowery language** — purple prose, excess adjectives, ornament for its own sake.
+- **Mannered, essayistic register** — "at the center of the answer is," "X answers Y's question." Write directly instead.
+- **Contrived parallels reached for rhythm** — "same input, same code, three different answers." Cover the parallel; if the plain fact remains, the structure was decoration.
+- **Mathematical-symmetry framings** — "the dual of," "the inverse of," "isomorphic to" for "the opposite of." Say it does the reverse, plainly.
+- **Definitional label-parallels** — "X is the A, Y the B," balanced clauses that say what things are and nothing about why they matter. Say what the thing does.
+- **Generic AI tells** — "it's worth noting that," "importantly," "interestingly," overly balanced hedging, and em-dashes on every other line. Cut them.
+
+All six are the same move: you reached for how it sounds instead of stating what is true. Cover the phrasing; if a fact is left, keep it; if not, write the fact in.
+
+## Never coin jargon
+
+Prose exists to explain. Never name what the code does in shorthand you minted on the spot: invented compounds ("green-skip," "main miss"), pseudo-technical labels. The tell is that the term reads like real vocabulary — next to "garbage collection" it looks legitimate — but nobody can decode it, because it means something mundane. Write what happens in plain words. Established domain terms, and terms the project itself defines, are fine.
+
+## Nothing that isn't a person acts
+
+Don't give a non-person noun knowledge, intent, sight, or a job. This is not only about code — run the check on every noun: a bug, a test, the data, the layout, the runtime, a release, a version, a change.
+
+Replace cognition and intent verbs (asks, answers, wants, knows, decides, tries, sees, watches, catches, "its job is to") with what the thing mechanically does (runs, compares, returns, finds, walks, computes, records). "The check asks whether the value is valid" → "the check compares the value against the bound." "The test catches the bug" → "the test fails when the value is wrong." A second class is static things given an action they can't take: a library, a release, a version, a change don't act at all. "The libraries picked up the change" → "we shipped new versions." The action belongs to a person or to a machine's literal operation; put it there.
+
+## The reader has only what you gave them
+
+Every "it," "this," "that" needs an obvious referent. If the antecedent isn't in the same or the previous sentence, name the thing. Unclear antecedents are a failure of craft, not a stylistic preference.
+
+Introduce a concept before you rely on it, and introduce it before you name it — the idea first, the label second. A term named once in a compressed clause is not taught. The same holds for capacious words ("the work," "tooling," "scale," "the problem"): anchor them to something concrete before you build on them, or the point that depends on them won't land.
+
+## Don't inflate, don't invent
+
+State what is true, and don't reach past it. Plain writing fails this way too — not by adding flourish, but by inflating the fact itself to sound more impressive.
+
+Don't write that something is "impossible" or "can't happen" when it is possible and only non-obvious. The honest word is "surprising" or "non-obvious," not "impossible" — and claiming a system does the impossible reads as not understanding it.
+
+Every claim about history, severity, size, or frequency is a factual claim. Verify it from the source or drop it. Don't invent specifics to fill a plausible-sounding sentence. And don't editorialize about what the reader knows — "obvious," "as everyone knows," "counterintuitive" all presume the reader's state; present the fact and let them react.
+
+## Don't pre-announce the shape of an explanation
+
+"The intuition, in two lines." "Both rules in one sentence." "How it works, in three steps." Just deliver the explanation. The reader can see the shape; the announcement is filler.
+
+## Aim at the problem, never the person
+
+When the prose is about someone else's code, PR, design, or decision — a bug report, a commit message, a release note, a review comment — aim every criticism at the problem, never at the person or their competence. The failure mode is subtle: quoting a stated goal and then declaring it false, a "why did nobody catch this" angle that lands as negligence, a closing jab at the work. Each reads as an exposé of the author even when that wasn't the intent. Credit what works, locate the cause in a structural reason (a subtle interaction, a pre-existing constraint) rather than in someone's carelessness, and stay direct about the problem while generous about the people.
+
+The same fact can be aimed at the problem or at the person. Which one you pick is how you say it — so it belongs here.
+
+## Where this sits
+
+This skill owns how the words read. It owns nothing about what to say or what to leave out — that is the form's job. `pony-comments` says what earns a comment; `pony-release-notes` says what belongs in a release note; the README skills say what a README holds. Load the form's skill for what to write, and this one for how to write it.

--- a/pony-release-notes/SKILL.md
+++ b/pony-release-notes/SKILL.md
@@ -6,6 +6,8 @@ disable-model-invocation: false
 
 # Pony Release Notes & CHANGELOG
 
+Load `pony-prose` for how the words read. This skill says what belongs in a release note; `pony-prose` says how to write it plainly.
+
 ## Writing Style
 
 **Release notes — write for end users, not developers**: Release notes describe user-visible changes only. Omit implementation details (internal refactoring, which functions changed, how the fix works). Focus on what the user experienced before, what they experience now, and why it matters. When introducing new API surface, include a short code example — a concise usage snippet communicates more than descriptive text. Changes that are only relevant to maintainers (internal documentation, code comments, refactoring with no user-visible effect) don't get release notes at all.

--- a/pony-skills/SKILL.md
+++ b/pony-skills/SKILL.md
@@ -11,6 +11,7 @@ When one of these applies, load the named skill.
 | When | Load |
 |---|---|
 | Working on Pony at all — before you start, and for questions about capabilities, the type system, the runtime, or testing | `pony-ref` |
+| Writing any prose that ships with the code — a comment, docstring, release note, README, issue, PR description, or commit message | `pony-prose` |
 | Before writing or changing a comment or docstring | `pony-comments` |
 | Designing APIs, types, features, or system boundaries (not just implementing an existing design) | `pony-software-design` |
 | Reviewing code, or before opening a PR | `pony-code-review` |


### PR DESCRIPTION
The skills said what belongs in a comment, a docstring, a release note, a README. None said the words themselves should read plainly: say a fact the reader can check, don't coin jargon, don't give a test or a bug a mind of its own. That guidance lived only inside the long-form writing skills, so a docstring or a release note never got it.

`pony-prose` holds it in one place, and every prose skill points at it. The code-review editor now reviews comments, docstrings, release notes, and READMEs against it, not just comments. `pony-comments` keeps what earns a comment; its jargon rule moves to `pony-prose`, where it covers every kind of prose.