### PR TITLE
Add pony-agents-md, the rulebook for what belongs in AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ What's in the `references/` directory (read on demand for deeper questions):
 
 #### pony-prose
 
-How the words read in any prose that ships with the code — comments, docstrings, release notes, READMEs, commit messages. Load it before writing any of them. It is the layer under the form-specific skills: they say what belongs in each kind of prose, this says how to write it plainly.
+How the words read in any prose that ships with the code — comments, docstrings, release notes, READMEs, a project's `AGENTS.md`, commit messages. Load it before writing any of them. It is the layer under the form-specific skills: they say what belongs in each kind of prose, this says how to write it plainly.
 
 What's in the quick reference:
 
@@ -99,6 +99,19 @@ What's in the quick reference:
 - Never write a fact with a shelf life (what CI runs, whether a test exists, a version, what the body does)
 - Never narrate history, list callers, or leave dead status prose
 - The coupling decision: remove it, pin it, or comment both ends — in that order
+
+#### pony-agents-md
+
+What earns a line in a project's `AGENTS.md`, and what never belongs in one. Load it before writing or changing `AGENTS.md` or `CLAUDE.md`. The file is read on every task in the repository, so it is the most expensive prose the project has — and the agent adding to it is the one who can least see that cost.
+
+What's in the quick reference:
+
+- A line earns its place only if reading it there is cheaper and truer than reading the code
+- Name the one thing in the code a fact is about; if you can name it, it belongs to that thing, not this file
+- Never describe the current code — a state table, a field list, a call sequence, a restated signature
+- What earns a line: the picture no single file can hold, the commands, the conventions, and the traps
+- When it goes out of date, delete it rather than update it
+- Don't review your own addition — spawn a cold reader that has not seen your change
 
 #### pony-examples-readme
 
@@ -150,7 +163,7 @@ Has full (8-persona) and lightweight (5-persona) modes. Full mode runs design (3
 
 Ensemble code review with specialized reviewer personas. Load it when conducting a code review of a PR, branch, or local changes.
 
-Has full (9-persona, iterative re-review) and lightweight (4-persona, single pass) modes. Personas cover correctness, security, performance, API design, test quality, adversarial scenarios, design principles, prose that breaks `pony-prose` or `pony-comments` (comments, docstrings, release notes, READMEs), and wildcard concerns.
+Has full (9-persona, iterative re-review) and lightweight (4-persona, single pass) modes. Personas cover correctness, security, performance, API design, test quality, adversarial scenarios, design principles, prose that breaks the rulebooks (comments, docstrings, release notes, READMEs, `AGENTS.md`), and wildcard concerns.
 
 #### pony-docs-review
 
@@ -210,11 +223,15 @@ Prefer to pick individually? Add any of these instead:
 
 ### pony-prose trigger
 
-> **Load `pony-prose` before writing prose that ships with the code**: Before writing or changing a comment, docstring, release note, README, issue, PR description, or commit message, load `pony-prose` — the rulebook for writing it plainly.
+> **Load `pony-prose` before writing prose that ships with the code**: Before writing or changing a comment, docstring, release note, README, `AGENTS.md`, issue, PR description, or commit message, load `pony-prose` — the rulebook for writing it plainly.
 
 ### pony-comments trigger
 
 > **Load `pony-comments` before writing a comment or docstring**: Before writing or changing any comment or docstring, load `pony-comments` — what earns a comment, what never belongs in one, and how to handle two distant things that must change together.
+
+### pony-agents-md trigger
+
+> **Load `pony-agents-md` before writing a project's `AGENTS.md`**: Before writing or changing `AGENTS.md` or `CLAUDE.md`, load `pony-agents-md` — what earns a line in a file that is read on every task, and what belongs to the code instead.
 
 ### pony-examples-readme trigger
 

--- a/pony-agents-md/SKILL.md
+++ b/pony-agents-md/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: pony-agents-md
+description: What belongs in a project's AGENTS.md and what never does. Load before writing or changing AGENTS.md or CLAUDE.md. Language-agnostic.
+disable-model-invocation: false
+---
+
+# AGENTS.md
+
+Every line in a project's `AGENTS.md` is paid for on every task in the repository, forever. No other prose the project has is read this often, by this many readers, none of whom asked for it. It is the most expensive writing in the repo per word, and the cost is invisible to the agent adding to it.
+
+Where a project keeps this content in `CLAUDE.md` instead, it is the same file under another name, and everything here applies to it.
+
+Load `pony-prose` first: it is the rulebook for how the words read. This skill is the rulebook for what earns a line.
+
+## The principle
+
+An agent lands here cold, with no memory of the last one. `AGENTS.md` exists to save it the cost of learning, again, what it cannot learn cheaply from the repository itself.
+
+> A line earns its place only if reading it here is cheaper and truer than how an agent would otherwise learn the same thing.
+
+Both halves matter, and the second is the one that gets lost. The code cannot drift from itself. A sentence here about the code is a second copy that no compiler checks and no test covers, so it starts out less true than the thing it describes and gets worse from there. To beat that, a line has to be *much* cheaper to read here, not marginally.
+
+Almost nothing about the code is.
+
+## The check
+
+Applying the principle line by line is slow. This is the fast version for a fact about the code, and it usually gives the same answer:
+
+> Name the one thing in the code this fact is about — a type, a function, a file.
+
+If you can name it, cut the line. An agent that needs the fact will be reading the thing the fact is about, and will find it there. The copy here is paid for by every agent that never looks.
+
+If you cannot name one thing — if the fact is about how the pieces relate, what shape they make, which idea the design turns on — then nothing owns it, no single file can hold it, and assembling it means reading the whole package. That is expensive, and this is its only home.
+
+The check is for facts about the code, because that is what this file fills up with. The commands, the conventions, and the traps below are not facts about the code, and it does not reach them.
+
+### When the check and the principle give different answers, the principle wins
+
+A fact about the code can have an owner and still earn its place, when the shape it belongs to cannot be recovered cheaply from that owner.
+
+A connection lifecycle is the case. Its state classes all live in one file, so the check names that file and evicts. But the shape is not written down anywhere in it: an agent has to know the lifecycle exists, know to go there, and read the file end to end to assemble the transitions out of the classes. Reading it out is expensive, so the principle says keep it and the check yields.
+
+The exception buys you one picture, of the package as a whole. It does not buy you a tour. Draw the lifecycle; do not tabulate what each state returns — the states hold that, and an agent reading a state has it. The moment you are covering subsystems one at a time, you have stopped drawing a picture and started transcribing the code, and no number of invocations of this exception makes that a picture.
+
+## The cut line usually goes nowhere
+
+The code already says it. That is *why* you could name the owner.
+
+Do not soften a deletion by moving the prose into a docstring. A docstring gives a caller what they need to use the thing correctly and says nothing about how it works — that is `pony-comments`, and a state table, a call sequence, or a restated signature breaks that rule on arrival. Moving such prose next to the code does not make it any more true; it only makes it harder to spot. Write a docstring when a caller needs one, on its own merits, under its own rulebook.
+
+## Never describe the current code
+
+The sentence you most want to write is the one that cost you the most to learn, and it is almost always a description of a body that someone is about to rewrite. Apply the check from `pony-comments` — the same rot, a different file:
+
+> If rewriting a body, without changing anything a caller relies on, would make this sentence false, it describes how the code works now. It does not belong here.
+
+A state table. A field list. A call sequence. A restated signature. An enumeration of callbacks. Each is a claim about the present tense of a body that will be rewritten.
+
+The picture is not an exception to this rule; it passes it. That `pony-comments` check is scoped to a body, and you can rewrite every method in a state class without changing the states or the transitions between them, so the picture survives. When a change really does alter the shape, the picture is *supposed* to change with it. That is not rot. That is the sentence being true.
+
+## What earns a line
+
+**The picture.** What the pieces are, how they relate, which idea the design turns on. No docstring can hold it, and it is what lets a cold agent start in the right place instead of reading three thousand lines to find out where that is. It is short.
+
+**The commands.** Build, test, run a single test. Especially the ones that fail if you guess them — a required flag, a target that is not the obvious one. An agent cannot derive these.
+
+**The conventions.** Rules an agent will otherwise break. Each reads as an instruction it could disobey: *dispose every actor a test listener creates, or the runtime will not exit and CI hangs.* If it does not read as an instruction, it is a description, and the rule above applies to it.
+
+**The traps.** A thing that was tried, shipped as a bug, and must not come back. Three parts: what you would naturally do, what happened when someone did, and don't. Name the pull request or the issue.
+
+The trap is the one thing here that the code cannot give you. The code records what is. Nothing in it records what was tried and rejected — so a plausible wrong idea, already had once and paid for once, will be had again by the next agent, and the one after that. This is the section that justifies the file existing.
+
+## Never
+
+**A source-tree listing.** `ls` is cheaper and it is never out of date.
+
+**A tutorial.** That is `examples/`, and the examples compile.
+
+**An API guide.** That is the package docstring, and it renders into the generated documentation.
+
+**A history.** Version control remembers. A trap is not a history — it is a live constraint that happens to carry a date.
+
+## When it is wrong, delete it
+
+An agent reports that `AGENTS.md` is out of date. The default is to delete the section, not to update it.
+
+If it describes the code and the code moved, it should never have been here. Updating leaves the same section in place for the next agent, longer and bound more tightly to the code than before — so it goes false again, sooner. Every staleness report answered with an edit makes the next one more likely.
+
+Update only what was meant to be here: a command, a convention, a trap, or a picture whose shape actually changed.
+
+A file that keeps going out of date is not under-maintained. It is describing something it was never supposed to describe.
+
+## Don't review your own addition
+
+You are the worst-placed agent in the project to judge what belongs here. You have just done the work. Every detail is loaded, every one was expensive, and all of it feels necessary. The agent this file is written for arrives knowing none of it — and that agent is the only one whose judgment counts, because it is the reader.
+
+So don't judge. Spawn the reader.
+
+Do this for a new section, a rewrite, or anything you would have to argue for. A one-line command fix does not need it.
+
+Give a fresh-context subagent two things: the repository, and the proposed `AGENTS.md` in full. Tell it not to read the diff, the branch, the git history, the pull request, or the issue. It has the repository, so it *can* reconstruct all of them, and the withholding only holds if you ask for it. If your harness loads `AGENTS.md` or `CLAUDE.md` into every agent it spawns, move the file out of the tree for the run — otherwise the reader is holding the thing you meant to withhold, and it will tell you what you want to hear.
+
+Its ignorance is not a limitation to design around. It is the reader's condition, and it is the only vantage from which the questions can be answered.
+
+Ask it two:
+
+1. **Take each section, and name the one thing in the code it is about.** Cut what it can name, unless the section draws a shape that cannot be recovered cheaply from the thing that owns it.
+
+2. **For what survives — is reading it here cheaper and truer than reading the code?** Make it defend each one. That a line is true, and that it is useful, is not the bar. The bar is that carrying it on every task, forever, beats the alternative way of learning it.
+
+It judges the whole file, not your change, so it will raise findings against sections you did not touch. Those don't block you. Before you set one aside, ask whether it means your change was scoped too small — the cleanup you are doing may be the place it belongs. What survives that question, capture and vet afterwards; `pony-vet-suspected-issues` has the procedure.
+
+Findings against what you added do block you. If you disagree with one, that is a question for a human, not a thing to overrule. You are the party with the conflict of interest.
+
+## Calibration
+
+The reader above tells you what to cut. It cannot tell you what is missing: it has read the file and the code, but it has not tried to *do* anything, so it has fumbled nothing.
+
+For that, run a cold agent on real work, once in a while. Hand it an ordinary task in the repository with `AGENTS.md` withheld, and watch: what it searches for twice, what it gets wrong, what it has to be told. That is what belongs in the file. Everything else in there is something you are paying for and nobody needed.

--- a/pony-code-review/SKILL.md
+++ b/pony-code-review/SKILL.md
@@ -81,9 +81,9 @@ When principles conflict, these values set the priority. We value the left side 
 
 3. **Create a temporary directory for evidence files.** Use `~/tmp/code-review-<timestamp>/`, where `<timestamp>` is seconds-precision (e.g., `2026-06-05-143052`). Pick a concrete path up front — substitute a real timestamp for `<timestamp>` and reuse that literal path verbatim in every subsequent step. Each shell command runs in a fresh process, so don't try to recompute the path. Each persona will write its detailed evidence to a file in this directory. Generate the file path for each persona (e.g., `correctness-evidence.md`) and pass it in the prompt.
 
-4. **Spawn 9 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. Each agent's prompt includes:
+4. **Spawn 9 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. When the change touches a project's `AGENTS.md` or `CLAUDE.md`, tell every persona so, scoped to that file: it is loaded into every agent on every task, `pony-agents-md` is its rulebook and is subtractive by design, and a large deletion from it is the intended shape of a fix, not a regression. Each agent's prompt includes:
 
-   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `pony-prose`, `pony-comments`, `pony-test-design`, `pony-pbt-patterns`, `pony-ref`), read that skill's content and include it in the agent prompt. The Editor persona reviews every kind of prose in the diff, and its rulebooks must be injected in full or it has no standard to review against: `pony-prose` always, plus the form skill for each kind of prose the change touches — `pony-comments` for comments and docstrings in code, `pony-release-notes` for release notes and CHANGELOG entries, `pony-library-readme` or `pony-examples-readme` for READMEs.
+   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `pony-prose`, `pony-comments`, `pony-test-design`, `pony-pbt-patterns`, `pony-ref`), read that skill's content and include it in the agent prompt. The Editor persona reviews every kind of prose in the diff, and its rulebooks must be injected in full or it has no standard to review against: `pony-prose` always, plus the form skill for each kind of prose the change touches — `pony-comments` for comments and docstrings in code, `pony-release-notes` for release notes and CHANGELOG entries, `pony-library-readme` or `pony-examples-readme` for READMEs, `pony-agents-md` when the change touches the project's `AGENTS.md` or `CLAUDE.md`.
    - The code-review principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project `AGENTS.md` if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
    - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
    - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
@@ -150,7 +150,7 @@ Lightweight mode runs 4 personas in a single pass with no iterative re-review. L
 |------|-------|
 | `correctness.md` | Logic, edge cases, completeness for valid inputs |
 | `adversarial.md` | Concrete break scenarios, backward from failure |
-| `editor.md` | Prose that breaks the rulebooks — comments, docstrings, release notes, READMEs — and leaked-artifact sweep |
+| `editor.md` | Prose that breaks the rulebooks — comments, docstrings, release notes, READMEs, `AGENTS.md` — and leaked-artifact sweep |
 
 Editor runs on every lightweight review: a small change can carry prose that breaks the rulebooks, or a review artifact left in the text, and no other lightweight persona reviews prose. It groups a file's small tightenings into one finding, so the review gets one entry rather than a list.
 
@@ -178,9 +178,9 @@ Pick whichever is most relevant to the change. If multiple conditions apply, pic
 
 3. **Create a temporary directory for evidence files.** Use `~/tmp/code-review-<timestamp>/`. Same convention as full mode.
 
-4. **Spawn 4 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. Each agent's prompt includes:
+4. **Spawn 4 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. When the change touches a project's `AGENTS.md` or `CLAUDE.md`, tell every persona so, scoped to that file: it is loaded into every agent on every task, `pony-agents-md` is its rulebook and is subtractive by design, and a large deletion from it is the intended shape of a fix, not a regression. Each agent's prompt includes:
 
-   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `pony-prose`, `pony-comments`, `pony-test-design`, `pony-pbt-patterns`, `pony-ref`), read that skill's content and include it in the agent prompt. The Editor persona reviews every kind of prose in the diff, and its rulebooks must be injected in full or it has no standard to review against: `pony-prose` always, plus the form skill for each kind of prose the change touches — `pony-comments` for comments and docstrings in code, `pony-release-notes` for release notes and CHANGELOG entries, `pony-library-readme` or `pony-examples-readme` for READMEs.
+   - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `pony-prose`, `pony-comments`, `pony-test-design`, `pony-pbt-patterns`, `pony-ref`), read that skill's content and include it in the agent prompt. The Editor persona reviews every kind of prose in the diff, and its rulebooks must be injected in full or it has no standard to review against: `pony-prose` always, plus the form skill for each kind of prose the change touches — `pony-comments` for comments and docstrings in code, `pony-release-notes` for release notes and CHANGELOG entries, `pony-library-readme` or `pony-examples-readme` for READMEs, `pony-agents-md` when the change touches the project's `AGENTS.md` or `CLAUDE.md`.
    - The code-review principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project `AGENTS.md` if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
    - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
    - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
@@ -304,5 +304,5 @@ The persona documents are in `personas/`. Full mode uses all 9; lightweight uses
 | `performance.md` | Architectural bottlenecks, then local waste |
 | `tests.md` | Test quality, missing tests, counterfactual reasoning |
 | `principles.md` | Systematic principles audit with evidence |
-| `editor.md` | Prose that breaks the rulebooks — comments, docstrings, release notes, READMEs — and leaked-artifact sweep |
+| `editor.md` | Prose that breaks the rulebooks — comments, docstrings, release notes, READMEs, `AGENTS.md` — and leaked-artifact sweep |
 | `wildcard.md` | Chaos agent — finds what the others miss |

--- a/pony-code-review/personas/editor.md
+++ b/pony-code-review/personas/editor.md
@@ -1,6 +1,6 @@
 # Editor Reviewer
 
-You are the editor. You review every kind of prose in the change — comments, docstrings, release notes, CHANGELOG entries, READMEs — for whether the words earn their place and read plainly. You treat every comment as a liability until proven otherwise: a comment goes false as the code around it moves, and the more comments there are, the harder it is to find the few that matter. Your default recommendation is to cut a comment unless a maintainer would write it again today, from scratch — but docstrings and the user-facing prose (release notes, READMEs) are the exception: you tighten them, never delete them. You don't author prose, you don't flag *missing* docs (Principles owns that), and you don't review behavior (Correctness and Adversarial own that).
+You are the editor. You review every kind of prose in the change — comments, docstrings, release notes, CHANGELOG entries, READMEs, and the project's `AGENTS.md` — for whether the words earn their place and read plainly. You treat every comment as a liability until proven otherwise: a comment goes false as the code around it moves, and the more comments there are, the harder it is to find the few that matter. Your default recommendation is to cut a comment unless a maintainer would write it again today, from scratch — but docstrings and the user-facing prose (release notes, READMEs) are the exception: you tighten them, never delete them. You don't author prose, you don't flag *missing* docs (Principles owns that), and you don't review behavior (Correctness and Adversarial own that).
 
 ## Your rulebooks
 
@@ -8,7 +8,9 @@ Two kinds, both provided in full in your prompt.
 
 `pony-prose` is the standard for *how the words read* in any prose: plainly, saying a checkable fact, no coined jargon, no anthropomorphizing, clear antecedents. It applies to every kind of prose in the change.
 
-The form skills are the standard for *what belongs* in each kind. `pony-comments` — what earns a comment at all, what never belongs in one, and what to do when two distant things must change together. `pony-release-notes` — what a release note describes. `pony-library-readme` and `pony-examples-readme` — what a README holds. You get the ones that match the prose the change touches.
+The form skills are the standard for *what belongs* in each kind. `pony-comments` — what earns a comment at all, what never belongs in one, and what to do when two distant things must change together. `pony-release-notes` — what a release note describes. `pony-library-readme` and `pony-examples-readme` — what a README holds. `pony-agents-md` — what earns a line in the project's `AGENTS.md`. You get the ones that match the prose the change touches.
+
+`AGENTS.md` is both a rulebook you review *against* and prose you review. Those are separate jobs and you do both: its conventions are your standard for the project's comments and line lengths, and when the change touches the file itself, it is a target like any other prose. Nothing else in the review looks at it.
 
 Every finding you raise cites a rule: one in these rulebooks, one in the project's own conventions, or the leaked-artifact sweep in rule 4, which no rulebook covers. Don't re-derive the rulebooks' rules here and don't invent new ones.
 
@@ -36,16 +38,18 @@ Every finding you raise cites a rule: one in these rulebooks, one in the project
 
 9. **Review release notes and READMEs against their own form skill.** These are prose too, and they reach users directly. A release note earns a finding when it describes the implementation instead of what the user sees, or names the dependency behind a fixed bug — `pony-release-notes` is the standard. A README earns one when it drifts from the structure its README skill defines. And `pony-prose` applies to both: the same plainness, the same "say a checkable fact," the same no-coined-jargon. "Default to cut" does not apply here — like docstrings, this is user-facing prose you tighten, not delete.
 
-10. **Your findings are defects, not suggestions.** Every one cites a broken rule or a leaked artifact. No tool checks these rules — the build passes with the prose exactly as written — which is why you are here. Never file a finding as "style," and never rank one so that it reads as optional; severity says what the prose costs a reader, not whether it gets fixed.
+10. **`AGENTS.md` is default-to-cut.** It is loaded on every task in the repository and is nobody's deliverable, so the carve-out that protects docstrings and user-facing prose does not reach it — it is the one kind of prose here where cutting is the default and the bar is highest. `pony-agents-md` is the rulebook; review against it rather than re-deriving it. The finding you will raise most is a section describing the current code — a state table, a call sequence, a restated signature — which belongs to the thing it describes, not to this file. Don't soften such a cut by proposing the prose move to a docstring; the default destination is nowhere, and `pony-comments` governs a docstring written on its own merits. You have the diff, so you are not the cold reader `pony-agents-md` has the author spawn: you are the backstop. Flag what the rulebook forbids, and don't try to work out what the file is *missing*.
 
-11. **Rank by what the prose costs a reader.** Prose that misleads costs the most: a shelf-life claim already false, a stale comment that contradicts the code, a leaked review artifact in a user-facing file (README, CHANGELOG, a public-API docstring), a release note describing internals, an anthropomorphized sentence that names an intent instead of a mechanism, so there is nothing a reader can check. Wordiness costs least. All of them get fixed.
+11. **Your findings are defects, not suggestions.** Every one cites a broken rule or a leaked artifact. No tool checks these rules — the build passes with the prose exactly as written — which is why you are here. Never file a finding as "style," and never rank one so that it reads as optional; severity says what the prose costs a reader, not whether it gets fixed.
 
-12. **Batch, don't drop.** Lead with the prose that misleads. Where a file has many small tightenings, group them into one finding with every rewrite listed. Batching is how a finding is presented. It is never a decision not to fix one.
+12. **Rank by what the prose costs a reader.** Prose that misleads costs the most: a shelf-life claim already false, a stale comment that contradicts the code, a leaked review artifact in a user-facing file (README, CHANGELOG, a public-API docstring), a release note describing internals, an anthropomorphized sentence that names an intent instead of a mechanism, so there is nothing a reader can check. Wordiness costs least. All of them get fixed.
+
+13. **Batch, don't drop.** Lead with the prose that misleads. Where a file has many small tightenings, group them into one finding with every rewrite listed. Batching is how a finding is presented. It is never a decision not to fix one.
 
 ## Context Loading
 
 - `pony-prose` is your rulebook for how the words read, provided in full — read it first; it applies to every kind of prose in the change
-- The form skills are your rulebooks for what belongs in each kind, provided in full for whatever the change touches: `pony-comments` for comments and docstrings, `pony-release-notes` for release notes and CHANGELOG entries, `pony-library-readme` / `pony-examples-readme` for READMEs
+- The form skills are your rulebooks for what belongs in each kind, provided in full for whatever the change touches: `pony-comments` for comments and docstrings, `pony-release-notes` for release notes and CHANGELOG entries, `pony-library-readme` / `pony-examples-readme` for READMEs, `pony-agents-md` for the project's `AGENTS.md`
 - Review also against the code-review principles provided in your prompt, and the project's `AGENTS.md` if it has one — the project's own comment, docstring, and line-length conventions are your standard for collapsing wordy inline comments, not a generic rule
 - If a Pony project, load `pony-ref` — docstring conventions and the `\nodoc\` annotation matter for deciding what's load-bearing
 - Read all changed files in full, code and prose alike — the leaked-artifact sweep covers every changed text file, not just source

--- a/pony-comments/SKILL.md
+++ b/pony-comments/SKILL.md
@@ -33,7 +33,7 @@ Run this check before you write, not after. It costs nothing:
 
 > If deleting a test or editing a workflow would make this sentence false, it does not belong in a comment.
 
-The information is still worth having. It belongs where the machinery is documented and maintained: the build file, the CI config, the project's `AGENTS.md`.
+The information is still worth having. It belongs where the machinery is documented and maintained: the build file, the CI config, the project's `AGENTS.md`. If it is the `AGENTS.md`, load `pony-agents-md` first — that file is read on every task in the repository, and it has its own bar for what earns a line.
 
 One word needs care. "Silently" is a fact about the program when it means the code produces a wrong value and raises nothing. It is a shelf-life claim when it means no test catches it. Only the first belongs in a comment.
 

--- a/pony-docs-review/SKILL.md
+++ b/pony-docs-review/SKILL.md
@@ -61,11 +61,11 @@ The pony-synthesize skill's output format is not a natural fit for documentation
 
 3. **Create a temporary directory for evidence files.** Use `~/tmp/pony-docs-review-<timestamp>/`. Each persona will write its detailed evidence to a file in this directory. Generate the file path for each persona (e.g., `accuracy-evidence.md`) and pass it in the prompt.
 
-4. **Spawn 9 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. Each agent's prompt includes:
+4. **Spawn 9 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. When the change touches a project's `AGENTS.md` or `CLAUDE.md`, tell every persona so, scoped to that file: it is loaded into every agent on every task, `pony-agents-md` is its rulebook and is subtractive by design, and findings that would add to it — a coverage gap, a thin section, a rough read — are out of scope. What belongs in it is established by the calibration run `pony-agents-md` describes, not by reading it. Each agent's prompt includes:
 
    - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill (e.g., `pony-ref`), read that skill's content and include it in the agent prompt.
    - The documentation principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project AGENTS.md if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
-   - **For the Editor persona specifically:** its rulebooks must be injected in full or it has no standard to review against — `pony-prose` always, plus the form skill for each kind of prose the change touches: `pony-library-readme` or `pony-examples-readme` for READMEs, `pony-release-notes` for release notes and CHANGELOG entries.
+   - **For the Editor persona specifically:** its rulebooks must be injected in full or it has no standard to review against — `pony-prose` always, plus the form skill for each kind of prose the change touches: `pony-library-readme` or `pony-examples-readme` for READMEs, `pony-release-notes` for release notes and CHANGELOG entries, `pony-agents-md` for the project's `AGENTS.md` or `CLAUDE.md`.
    - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
    - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
    - Relevant gathered context from step 2, distributed to the personas that consume it (e.g. source code for Accuracy; related docs or style guides for Consistency or Principles when they run).
@@ -159,11 +159,11 @@ Pick whichever is most relevant to the change. If multiple conditions apply, pic
 
 3. **Create a temporary directory for evidence files.** Use `~/tmp/pony-docs-review-<timestamp>/`. Same convention as full mode.
 
-4. **Spawn 4 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. Each agent's prompt includes:
+4. **Spawn 4 persona agents in parallel**, each as a fresh-context sub-agent using your most capable model. When the change touches a project's `AGENTS.md` or `CLAUDE.md`, tell every persona so, scoped to that file: it is loaded into every agent on every task, `pony-agents-md` is its rulebook and is subtractive by design, and findings that would add to it — a coverage gap, a thin section, a rough read — are out of scope. What belongs in it is established by the calibration run `pony-agents-md` describes, not by reading it. Each agent's prompt includes:
 
    - The persona document, read from the corresponding file in `personas/`. When a persona's context loading references an external skill, read that skill's content and include it in the agent prompt.
    - The documentation principles: read `references/principles.md` (alongside this skill) and include its content in the agent prompt, the same way referenced skills are injected above. Also instruct the agent to read the project AGENTS.md if one exists (not all projects have one; if absent, note it and proceed) and to follow its conventions, including loading any skills it references.
-   - **For the Editor persona specifically:** its rulebooks must be injected in full or it has no standard to review against — `pony-prose` always, plus the form skill for each kind of prose the change touches: `pony-library-readme` or `pony-examples-readme` for READMEs, `pony-release-notes` for release notes and CHANGELOG entries.
+   - **For the Editor persona specifically:** its rulebooks must be injected in full or it has no standard to review against — `pony-prose` always, plus the form skill for each kind of prose the change touches: `pony-library-readme` or `pony-examples-readme` for READMEs, `pony-release-notes` for release notes and CHANGELOG entries, `pony-agents-md` for the project's `AGENTS.md` or `CLAUDE.md`.
    - The review target: base branch, diff command, PR URL, and any related issue/discussion URLs.
    - Instructions to read all changed files in full (not just diffs), plus supporting files needed for context.
    - Relevant gathered context from step 2, distributed to the personas that consume it (e.g. source code for Accuracy; related docs or style guides for Consistency or Principles when they run).

--- a/pony-docs-review/personas/completeness.md
+++ b/pony-docs-review/personas/completeness.md
@@ -2,6 +2,8 @@
 
 You trace the reader's path through the documentation and identify where they would get stuck because information is missing. Your scope is coverage gaps — prerequisites the reader needs but the document doesn't state, steps that are skipped, assumptions that aren't called out, concepts that are referenced but never explained. You don't evaluate whether existing content is correct (Accuracy handles that), whether its prose obeys the rulebooks (Editor handles that), or whether it reaches its audience (Clarity handles that) — you find what's absent.
 
+The project's `AGENTS.md` is outside your scope, and this is the one document where a coverage gap is not a finding. It is loaded into every agent on every task, so a line in it that nobody needed is a cost paid forever; its rulebook, `pony-agents-md`, is subtractive by design, and most of what looks like a gap in it is content that belongs to the code. What genuinely belongs in it cannot be found by reading it — only by watching a cold agent work without it, which `pony-agents-md` calls calibration and which no reviewer holding the diff can do. Raise nothing against it.
+
 ## Core Principles
 
 1. **Trace the reader's journey step by step.** For procedural content (tutorials, guides, installation docs), walk through every step as if you were the reader. At each step, ask: does the reader have everything they need to proceed? If a step requires knowledge, tools, permissions, or context that wasn't provided earlier, that's a gap.

--- a/pony-docs-review/personas/editor.md
+++ b/pony-docs-review/personas/editor.md
@@ -1,6 +1,6 @@
 # Editor Reviewer
 
-You are the editor. You review the documentation's prose against the rulebooks — whether the words earn their place and read plainly. Documentation is prose end to end, so every line of the change is yours. Everything you review is user-facing, so you tighten and never delete: shorten a wordy sentence rather than cutting it, and never cut the fact out along with the words. You don't add prose the change lacks. You don't check whether the content is true (Accuracy owns that), whether anything is missing (Completeness owns that), or whether the target audience can follow it (Clarity owns that). You check whether the prose obeys the rulebooks.
+You are the editor. You review the documentation's prose against the rulebooks — whether the words earn their place and read plainly. Documentation is prose end to end, so every line of the change is yours. Almost everything you review is user-facing, so you tighten and never delete: shorten a wordy sentence rather than cutting it, and never cut the fact out along with the words. The project's `AGENTS.md` is the exception, and it is the reverse: nobody chose to read it, it is loaded on every task in the repository, and it is default-to-cut. `pony-agents-md` is its rulebook. You don't add prose the change lacks. You don't check whether the content is true (Accuracy owns that), whether anything is missing (Completeness owns that), or whether the target audience can follow it (Clarity owns that). You check whether the prose obeys the rulebooks.
 
 ## Your rulebooks
 
@@ -8,7 +8,7 @@ Provided in full in your prompt.
 
 `pony-prose` is the standard for *how the words read* in any prose: plainly, saying a checkable fact, no coined jargon, no anthropomorphizing, clear antecedents, no flourish standing in for content, no inflating past what is true.
 
-The form skills are the standard for *what belongs* in each kind. `pony-library-readme` and `pony-examples-readme` — what a README holds. `pony-release-notes` — what a release note describes. You get the ones that match the prose the change touches.
+The form skills are the standard for *what belongs* in each kind. `pony-library-readme` and `pony-examples-readme` — what a README holds. `pony-release-notes` — what a release note describes. `pony-agents-md` — what earns a line in the project's `AGENTS.md`. You get the ones that match the prose the change touches.
 
 Every finding you raise names a rule, with two exceptions: the artifact sweep in rule 3, which no rulebook covers, and the project's own conventions in its `AGENTS.md`. Don't re-derive the rulebooks' rules here and don't invent new ones.
 
@@ -39,6 +39,6 @@ Every finding you raise names a rule, with two exceptions: the artifact sweep in
 ## Context Loading
 
 - `pony-prose` is your rulebook for how the words read, provided in full — read it first; it applies to every line of the change
-- The form skills for the prose the change touches — `pony-library-readme`, `pony-examples-readme`, `pony-release-notes` — provided in full when they apply
+- The form skills for the prose the change touches — `pony-library-readme`, `pony-examples-readme`, `pony-release-notes`, `pony-agents-md` — provided in full when they apply
 - Read the full changed documentation, not just diffs — flourish and repetition are visible only against what surrounds them
 - The project's `AGENTS.md` if it has one, for conventions the rulebooks don't cover

--- a/pony-prose/SKILL.md
+++ b/pony-prose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pony-prose
-description: How the words go in a comment, docstring, release note, or README — write plainly, say the fact, and stop. Load before writing any prose that ships with the code. Language-agnostic.
+description: How the words go in a comment, docstring, release note, README, or a project's AGENTS.md — write plainly, say the fact, and stop. Load before writing any prose that ships with the code. Language-agnostic.
 disable-model-invocation: false
 ---
 
@@ -8,7 +8,7 @@ disable-model-invocation: false
 
 The form tells you what to say. This tells you how to say it.
 
-A comment, a docstring, a release note, a CHANGELOG entry, a README, an issue body, a PR description, a commit message — each has a skill that says what belongs in it and what to leave out. This skill is the layer under all of them: how the words themselves read once you've decided what to write. Load it alongside the form's own skill.
+A comment, a docstring, a release note, a CHANGELOG entry, a README, a project's `AGENTS.md`, an issue body, a PR description, a commit message — each has a skill that says what belongs in it and what to leave out. This skill is the layer under all of them: how the words themselves read once you've decided what to write. Load it alongside the form's own skill.
 
 ## Plain is where you stop
 
@@ -71,4 +71,4 @@ The same fact can be aimed at the problem or at the person. Which one you pick i
 
 ## Where this sits
 
-This skill owns how the words read. It owns nothing about what to say or what to leave out — that is the form's job. `pony-comments` says what earns a comment; `pony-release-notes` says what belongs in a release note; the README skills say what a README holds. Load the form's skill for what to write, and this one for how to write it.
+This skill owns how the words read. It owns nothing about what to say or what to leave out — that is the form's job. `pony-comments` says what earns a comment; `pony-release-notes` says what belongs in a release note; the README skills say what a README holds; `pony-agents-md` says what earns a line in a project's `AGENTS.md`. Load the form's skill for what to write, and this one for how to write it.

--- a/pony-skills/SKILL.md
+++ b/pony-skills/SKILL.md
@@ -11,8 +11,9 @@ When one of these applies, load the named skill.
 | When | Load |
 |---|---|
 | Working on Pony at all — before you start, and for questions about capabilities, the type system, the runtime, or testing | `pony-ref` |
-| Writing any prose that ships with the code — a comment, docstring, release note, README, issue, PR description, or commit message | `pony-prose` |
+| Writing any prose that ships with the code — a comment, docstring, release note, README, `AGENTS.md`, issue, PR description, or commit message | `pony-prose` |
 | Before writing or changing a comment or docstring | `pony-comments` |
+| Before writing or changing a project's `AGENTS.md` or `CLAUDE.md` | `pony-agents-md` |
 | Designing APIs, types, features, or system boundaries (not just implementing an existing design) | `pony-software-design` |
 | Reviewing code, or before opening a PR | `pony-code-review` |
 | Reviewing a documentation-only change | `pony-docs-review` |


### PR DESCRIPTION
A new skill, `pony-agents-md`, that loads before you write or change a project's `AGENTS.md` and tells you what earns a line in it.

Left alone, an `AGENTS.md` fills up with descriptions of the current code — a listing of the source tree, a section per subsystem — that duplicate the docstrings beside that code and go stale on nearly every change. This skill sets one bar: a line belongs only if reading it there is cheaper and truer than reading the code. That keeps the build commands, the project conventions, and the traps someone learned the hard way, and turns away the descriptions. When the file goes out of date, the guidance is to delete the stale part rather than update it, and to have a fresh agent that hasn't seen your change read the result before it lands.

The `pony-code-review` and `pony-docs-review` editors now review `AGENTS.md` against the skill, and the docs-review completeness persona no longer reports a trimmed `AGENTS.md` as missing content.
