### PR TITLE
Trigger CI workflows only on relevant paths

### DIFF
--- a/.github/workflows/lint-action-workflows.yml
+++ b/.github/workflows/lint-action-workflows.yml
@@ -1,6 +1,9 @@
 name: Lint GitHub Action Workflows
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
 
 concurrency:
   group: lint-actions-${{ github.ref }}

--- a/.github/workflows/pr-repo-hygiene.yml
+++ b/.github/workflows/pr-repo-hygiene.yml
@@ -1,6 +1,19 @@
 name: Repository Hygiene
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      # super-linter checks bash, markdown, and yaml. Skill dirs (pony-*/) hold
+      # markdown we don't lint, so a skill-only change shouldn't trigger this
+      # workflow; the negation sits before the yaml/bash globs so a non-markdown
+      # file under a skill dir still would.
+      - '**.md'
+      - '!pony-*/**'
+      - '**.yml'
+      - '**.yaml'
+      - '**.sh'
+      - '**.bash'
+      - '.markdownlintignore'
 
 concurrency:
   group: pr-repo-hygiene-${{ github.ref }}
@@ -23,11 +36,3 @@ jobs:
           VALIDATE_BASH: true
           VALIDATE_MD: true
           VALIDATE_YAML: true
-
-  refresh-website-content:
-    name: Verify refresh-website-content script runs successfully
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - name: Run refresh-website-content.sh
-        run: .ci-scripts/refresh-website-content.sh

--- a/.github/workflows/verify-refresh-website-content.yml
+++ b/.github/workflows/verify-refresh-website-content.yml
@@ -1,0 +1,22 @@
+name: Verify Refresh Website Content Script
+
+on:
+  pull_request:
+    paths:
+      - '.ci-scripts/refresh-website-content.sh'
+
+concurrency:
+  group: verify-refresh-website-content-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify refresh-website-content script runs successfully
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Run refresh-website-content.sh
+        run: .ci-scripts/refresh-website-content.sh


### PR DESCRIPTION
The lint and hygiene workflows ran on every pull request. A PR that only touched a skill still ran actionlint and super-linter, which don't apply to skill content. Each PR-triggered workflow now triggers only on the paths it checks:

- Lint GitHub Action Workflows → `.github/workflows/**`
- Repository Hygiene (super-linter) → bash, markdown, and yaml, excluding skill directories
- The refresh-website-content script check → the script itself, now in its own workflow

Repository Hygiene had to split because a path filter gates a whole workflow, not one job, and its two jobs care about different files.

The already-gated workflows (lint-changelog, lint-install, pr-merge-changelog) and the event-driven ones (both discuss-during-sync workflows, the scheduled refresh-website-content) are unchanged.